### PR TITLE
feat: add QuickBase Pipelines tools via browser relay

### DIFF
--- a/env.example
+++ b/env.example
@@ -6,6 +6,11 @@ QB_USER_TOKEN=your_quickbase_user_token_here
 QB_DEFAULT_TIMEOUT=30000
 QB_MAX_RETRIES=3
 
+# Pipeline Browser Relay (Unofficial API)
+# Port for the local relay server used by the QB Pipeline bookmarklet.
+# Default: 3737. Visit http://localhost:<port>/setup for first-time setup.
+# QB_RELAY_PORT=3737
+
 # MCP Server Configuration
 MCP_SERVER_NAME=quickbase-mcp
 MCP_SERVER_VERSION=1.0.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -507,15 +507,19 @@ class QuickBaseMCPServer {
 
       quickbase_list_pipelines: async (args) => {
         const a = parseArgs('quickbase_list_pipelines', ListPipelinesSchema, args);
-        return JSON.stringify(
-          await getClient(a.appId).listPipelines({
-            pageNumber: a.pageNumber,
-            pageSize: a.pageSize,
-            realmWide: a.realmWide,
-            impersonateUserId: a.impersonateUserId
-          }),
-          null, 2
-        );
+        const result = await getClient(a.appId).listPipelines({
+          pageNumber: a.pageNumber,
+          pageSize: a.pageSize,
+          realmWide: a.realmWide,
+          impersonateUserId: a.impersonateUserId
+        });
+        const annotated = {
+          _viewingAs: a.impersonateUserId
+            ? `user ${a.impersonateUserId} (impersonated — your browser session was unaffected)`
+            : 'logged-in browser user (pass impersonateUserId to view another user\'s pipelines; use quickbase_find_pipeline_users to look up a user ID)',
+          ...result
+        };
+        return JSON.stringify(annotated, null, 2);
       },
 
       quickbase_get_pipeline: async (args) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -516,7 +516,7 @@ class QuickBaseMCPServer {
         const annotated = {
           _viewingAs: a.impersonateUserId
             ? `user ${a.impersonateUserId} (impersonated — your browser session was unaffected)`
-            : 'logged-in browser user (pass impersonateUserId to view another user\'s pipelines; use quickbase_find_pipeline_users to look up a user ID)',
+            : 'logged-in browser user',
           ...result
         };
         return JSON.stringify(annotated, null, 2);
@@ -524,21 +524,33 @@ class QuickBaseMCPServer {
 
       quickbase_get_pipeline: async (args) => {
         const a = parseArgs('quickbase_get_pipeline', GetPipelineSchema, args);
+        const result = await getClient(a.appId).getPipelineDetail(a.pipelineId, a.impersonateUserId);
         return JSON.stringify(
-          await getClient(a.appId).getPipelineDetail(a.pipelineId, a.impersonateUserId),
+          {
+            _viewingAs: a.impersonateUserId
+              ? `user ${a.impersonateUserId} (impersonated — your browser session was unaffected)`
+              : 'logged-in browser user',
+            ...result
+          },
           null, 2
         );
       },
 
       quickbase_get_pipeline_activity: async (args) => {
         const a = parseArgs('quickbase_get_pipeline_activity', GetPipelineActivitySchema, args);
+        const result = await getClient(a.appId).getPipelineActivity(a.pipelineId, {
+          startDate: a.startDate,
+          endDate: a.endDate,
+          perPage: a.perPage,
+          impersonateUserId: a.impersonateUserId
+        });
         return JSON.stringify(
-          await getClient(a.appId).getPipelineActivity(a.pipelineId, {
-            startDate: a.startDate,
-            endDate: a.endDate,
-            perPage: a.perPage,
-            impersonateUserId: a.impersonateUserId
-          }),
+          {
+            _viewingAs: a.impersonateUserId
+              ? `user ${a.impersonateUserId} (impersonated — your browser session was unaffected)`
+              : 'logged-in browser user',
+            ...result
+          },
           null, 2
         );
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 import { QuickBaseClient } from './quickbase/client.js';
+import { startRelayServer, RelayClient } from './relay/server.js';
 import {
   quickbaseTools,
   TableIdSchema,
@@ -33,7 +34,12 @@ import {
   TestWebhookSchema,
   CreateNotificationSchema,
   ListNotificationsSchema,
-  DeleteNotificationSchema
+  DeleteNotificationSchema,
+  ListPipelinesSchema,
+  GetPipelineSchema,
+  GetPipelineActivitySchema,
+  FindPipelineUsersSchema,
+  StartImpersonationSchema
 } from './tools/index.js';
 import { AppConfig, QuickBaseConfig } from './types/quickbase.js';
 import { loadAppRegistry, loadDotenv } from './utils/env.js';
@@ -102,6 +108,7 @@ class QuickBaseMCPServer {
   private baseConfig: Omit<QuickBaseConfig, 'appId'>;
   private appRegistry: Map<string, AppConfig>;
   private clientCache: Map<string, QuickBaseClient>;
+  private relayClient: RelayClient | null = null;
   private readonly serverName: string;
   private readonly serverVersion: string;
 
@@ -131,6 +138,9 @@ class QuickBaseMCPServer {
     this.serverName = process.env.MCP_SERVER_NAME || 'quickbase-mcp';
     this.serverVersion = process.env.MCP_SERVER_VERSION || '1.0.0';
 
+    const relayPort = parseEnvInt('QB_RELAY_PORT', 3737);
+    this.relayClient = startRelayServer(realm, relayPort);
+
     this.server = new Server(
       { name: this.serverName, version: this.serverVersion },
       { capabilities: { tools: {} } }
@@ -155,6 +165,7 @@ class QuickBaseMCPServer {
     const cached = this.clientCache.get(appId);
     if (cached) return cached;
     const client = new QuickBaseClient({ ...this.baseConfig, appId });
+    if (this.relayClient) client.setRelayClient(this.relayClient);
     this.clientCache.set(appId, client);
     return client;
   }
@@ -490,6 +501,60 @@ class QuickBaseMCPServer {
         const a = parseArgs('quickbase_delete_notification', DeleteNotificationSchema, args);
         await getClient(a.appId).deleteNotification(a.tableId, a.notificationId);
         return JSON.stringify({ success: true, message: `Notification ${a.notificationId} deleted successfully` }, null, 2);
+      },
+
+      // ========== PIPELINES (Unofficial API) ==========
+
+      quickbase_list_pipelines: async (args) => {
+        const a = parseArgs('quickbase_list_pipelines', ListPipelinesSchema, args);
+        return JSON.stringify(
+          await getClient(a.appId).listPipelines({
+            pageNumber: a.pageNumber,
+            pageSize: a.pageSize,
+            realmWide: a.realmWide,
+            impersonateUserId: a.impersonateUserId
+          }),
+          null, 2
+        );
+      },
+
+      quickbase_get_pipeline: async (args) => {
+        const a = parseArgs('quickbase_get_pipeline', GetPipelineSchema, args);
+        return JSON.stringify(
+          await getClient(a.appId).getPipelineDetail(a.pipelineId, a.impersonateUserId),
+          null, 2
+        );
+      },
+
+      quickbase_get_pipeline_activity: async (args) => {
+        const a = parseArgs('quickbase_get_pipeline_activity', GetPipelineActivitySchema, args);
+        return JSON.stringify(
+          await getClient(a.appId).getPipelineActivity(a.pipelineId, {
+            startDate: a.startDate,
+            endDate: a.endDate,
+            perPage: a.perPage,
+            impersonateUserId: a.impersonateUserId
+          }),
+          null, 2
+        );
+      },
+
+      quickbase_find_pipeline_users: async (args) => {
+        const a = parseArgs('quickbase_find_pipeline_users', FindPipelineUsersSchema, args);
+        return JSON.stringify(await getClient(a.appId).findPipelineUsers(a.query), null, 2);
+      },
+
+      quickbase_start_impersonation: async (args) => {
+        const a = parseArgs('quickbase_start_impersonation', StartImpersonationSchema, args);
+        return JSON.stringify(
+          await getClient(a.appId).startPipelineImpersonation(a.qbUserId),
+          null, 2
+        );
+      },
+
+      quickbase_end_impersonation: async (args) => {
+        const a = parseArgs('quickbase_end_impersonation', z.object({ appId: z.string().min(1).max(64) }), args);
+        return JSON.stringify(await getClient(a.appId).endPipelineImpersonation(), null, 2);
       },
     };
   }

--- a/src/quickbase/client.ts
+++ b/src/quickbase/client.ts
@@ -1079,8 +1079,18 @@ export class QuickBaseClient {
     const { perPage = 25, impersonateUserId } = opts;
 
     const now = Math.floor(Date.now() / 1000);
-    const start = opts.startDate ? Math.floor(new Date(opts.startDate).getTime() / 1000) : now - 7 * 86400;
-    const end = opts.endDate ? Math.floor(new Date(opts.endDate).getTime() / 1000) : now;
+
+    const startMs = opts.startDate ? new Date(opts.startDate).getTime() : NaN;
+    if (opts.startDate && isNaN(startMs)) {
+      throw new McpError(ErrorCode.InvalidParams, `Invalid startDate: "${opts.startDate}" is not a valid date`);
+    }
+    const endMs = opts.endDate ? new Date(opts.endDate).getTime() : NaN;
+    if (opts.endDate && isNaN(endMs)) {
+      throw new McpError(ErrorCode.InvalidParams, `Invalid endDate: "${opts.endDate}" is not a valid date`);
+    }
+
+    const start = opts.startDate ? Math.floor(startMs / 1000) : now - 7 * 86400;
+    const end = opts.endDate ? Math.floor(endMs / 1000) : now;
 
     // Multi-value scope params must use append() — URLSearchParams constructor
     // would merge duplicate keys into a single value, losing 'pipe' and 'poller'.

--- a/src/quickbase/client.ts
+++ b/src/quickbase/client.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { QuickBaseConfig, QuickBaseField, QuickBaseTable, QuickBaseRecord, QueryOptions } from '../types/quickbase.js';
 import { RelayClient } from '../relay/server.js';
 import { envFlag } from '../utils/env.js';
@@ -1014,6 +1015,22 @@ export class QuickBaseClient {
     return this.relayClient;
   }
 
+  /**
+   * Unwrap a relay result, throwing a descriptive McpError on non-2xx status or
+   * network-level errors (status === 0). Keeps all pipeline methods DRY.
+   */
+  private unwrapRelayResult(result: { status: number; data: unknown; error?: string }): unknown {
+    if (result.error || result.status === 0 || result.status >= 400) {
+      const detail = result.error
+        ?? (result.data != null ? JSON.stringify(result.data) : 'no details returned');
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Pipeline API error (HTTP ${result.status}): ${detail}`
+      );
+    }
+    return result.data;
+  }
+
   // ========== PIPELINE METHODS (Unofficial API — may break without notice) ==========
 
   async listPipelines(opts: {
@@ -1032,7 +1049,7 @@ export class QuickBaseClient {
         'POST',
         { tags: [], channels: [], users: [], searchString: '', requestRealmPipelines: realmWide }
       );
-      return result.data;
+      return this.unwrapRelayResult(result);
     } finally {
       if (impersonateUserId) await this.endPipelineImpersonation().catch(() => {});
     }
@@ -1046,7 +1063,7 @@ export class QuickBaseClient {
         `/api/v2/pipelines/${encodeURIComponent(pipelineId)}/designer?open=true`,
         'GET'
       );
-      return result.data;
+      return this.unwrapRelayResult(result);
     } finally {
       if (impersonateUserId) await this.endPipelineImpersonation().catch(() => {});
     }
@@ -1065,20 +1082,23 @@ export class QuickBaseClient {
     const start = opts.startDate ? Math.floor(new Date(opts.startDate).getTime() / 1000) : now - 7 * 86400;
     const end = opts.endDate ? Math.floor(new Date(opts.endDate).getTime() / 1000) : now;
 
-    const qs = new URLSearchParams({
-      start: String(start),
-      end: String(end),
-      scope: 'pipeline',
-      per_page: String(perPage),
-      pipeline_id: pipelineId,
-      pipeline_run_id: '',
-      offset: ''
-    });
+    // Multi-value scope params must use append() — URLSearchParams constructor
+    // would merge duplicate keys into a single value, losing 'pipe' and 'poller'.
+    const qs = new URLSearchParams();
+    qs.append('start', String(start));
+    qs.append('end', String(end));
+    qs.append('scope', 'pipe');
+    qs.append('scope', 'poller');
+    qs.append('scope', 'pipeline');
+    qs.append('per_page', String(perPage));
+    qs.append('pipeline_id', pipelineId);
+    qs.append('pipeline_run_id', '');
+    qs.append('offset', '');
 
     if (impersonateUserId) await this.startPipelineImpersonation(impersonateUserId);
     try {
       const result = await relay.request(`/api/v2/activity?${qs.toString()}`, 'GET');
-      return result.data;
+      return this.unwrapRelayResult(result);
     } finally {
       if (impersonateUserId) await this.endPipelineImpersonation().catch(() => {});
     }
@@ -1090,7 +1110,7 @@ export class QuickBaseClient {
       `/api/realm/findmatchingusers/${encodeURIComponent(query)}`,
       'GET'
     );
-    return result.data;
+    return this.unwrapRelayResult(result);
   }
 
   async startPipelineImpersonation(qbUserId: string): Promise<any> {
@@ -1100,12 +1120,12 @@ export class QuickBaseClient {
       'POST',
       { qb_user_id: qbUserId }
     );
-    return result.data;
+    return this.unwrapRelayResult(result);
   }
 
   async endPipelineImpersonation(): Promise<any> {
     const relay = this.requireRelay();
     const result = await relay.request('/api/impersonation/end', 'POST', {});
-    return result.data;
+    return this.unwrapRelayResult(result);
   }
 }

--- a/src/quickbase/client.ts
+++ b/src/quickbase/client.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { QuickBaseConfig, QuickBaseField, QuickBaseTable, QuickBaseRecord, QueryOptions } from '../types/quickbase.js';
+import { RelayClient } from '../relay/server.js';
 import { envFlag } from '../utils/env.js';
 import { formatErrorForLog } from '../utils/errors.js';
 
@@ -7,6 +8,7 @@ export class QuickBaseClient {
   private axios: AxiosInstance;
   private config: QuickBaseConfig;
   private logApi: boolean;
+  private relayClient: RelayClient | null = null;
 
   private static extractCreatedRecordIds(responseData: any): number[] {
     const normalizeIds = (ids: unknown[]): number[] =>
@@ -997,4 +999,113 @@ export class QuickBaseClient {
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&apos;');
   }
-} 
+
+  // ========== RELAY CLIENT ==========
+
+  /** Inject the relay client after construction (avoids circular dependency). */
+  setRelayClient(relay: RelayClient): void {
+    this.relayClient = relay;
+  }
+
+  private requireRelay(): RelayClient {
+    if (!this.relayClient) {
+      throw new Error('Pipeline relay client is not configured. Ensure the relay server started successfully.');
+    }
+    return this.relayClient;
+  }
+
+  // ========== PIPELINE METHODS (Unofficial API — may break without notice) ==========
+
+  async listPipelines(opts: {
+    pageNumber?: number;
+    pageSize?: number;
+    realmWide?: boolean;
+    impersonateUserId?: string;
+  } = {}): Promise<any> {
+    const relay = this.requireRelay();
+    const { pageNumber = 1, pageSize = 25, realmWide = false, impersonateUserId } = opts;
+
+    if (impersonateUserId) await this.startPipelineImpersonation(impersonateUserId);
+    try {
+      const result = await relay.request(
+        `/api/v2/pipelines/query/paged?pageNumber=${pageNumber}&pageSize=${pageSize}`,
+        'POST',
+        { tags: [], channels: [], users: [], searchString: '', requestRealmPipelines: realmWide }
+      );
+      return result.data;
+    } finally {
+      if (impersonateUserId) await this.endPipelineImpersonation().catch(() => {});
+    }
+  }
+
+  async getPipelineDetail(pipelineId: string, impersonateUserId?: string): Promise<any> {
+    const relay = this.requireRelay();
+    if (impersonateUserId) await this.startPipelineImpersonation(impersonateUserId);
+    try {
+      const result = await relay.request(
+        `/api/v2/pipelines/${encodeURIComponent(pipelineId)}/designer?open=true`,
+        'GET'
+      );
+      return result.data;
+    } finally {
+      if (impersonateUserId) await this.endPipelineImpersonation().catch(() => {});
+    }
+  }
+
+  async getPipelineActivity(pipelineId: string, opts: {
+    startDate?: string;
+    endDate?: string;
+    perPage?: number;
+    impersonateUserId?: string;
+  } = {}): Promise<any> {
+    const relay = this.requireRelay();
+    const { perPage = 25, impersonateUserId } = opts;
+
+    const now = Math.floor(Date.now() / 1000);
+    const start = opts.startDate ? Math.floor(new Date(opts.startDate).getTime() / 1000) : now - 7 * 86400;
+    const end = opts.endDate ? Math.floor(new Date(opts.endDate).getTime() / 1000) : now;
+
+    const qs = new URLSearchParams({
+      start: String(start),
+      end: String(end),
+      scope: 'pipeline',
+      per_page: String(perPage),
+      pipeline_id: pipelineId,
+      pipeline_run_id: '',
+      offset: ''
+    });
+
+    if (impersonateUserId) await this.startPipelineImpersonation(impersonateUserId);
+    try {
+      const result = await relay.request(`/api/v2/activity?${qs.toString()}`, 'GET');
+      return result.data;
+    } finally {
+      if (impersonateUserId) await this.endPipelineImpersonation().catch(() => {});
+    }
+  }
+
+  async findPipelineUsers(query: string): Promise<any> {
+    const relay = this.requireRelay();
+    const result = await relay.request(
+      `/api/realm/findmatchingusers/${encodeURIComponent(query)}`,
+      'GET'
+    );
+    return result.data;
+  }
+
+  async startPipelineImpersonation(qbUserId: string): Promise<any> {
+    const relay = this.requireRelay();
+    const result = await relay.request(
+      '/api/impersonation/realm/start',
+      'POST',
+      { qb_user_id: qbUserId }
+    );
+    return result.data;
+  }
+
+  async endPipelineImpersonation(): Promise<any> {
+    const relay = this.requireRelay();
+    const result = await relay.request('/api/impersonation/end', 'POST', {});
+    return result.data;
+  }
+}

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -377,18 +377,33 @@ export function startRelayServer(realm: string, port: number): RelayClient {
     res.writeHead(404).end();
   });
 
-  server.listen(port, '127.0.0.1', () => {
-    console.error(`QB Pipeline relay server listening on http://127.0.0.1:${port}`);
-    console.error(`  Setup page: http://localhost:${port}/setup`);
-  });
+  let retried = false;
+
+  function tryListen(): void {
+    server.listen(port, '127.0.0.1', () => {
+      console.error(`QB Pipeline relay server listening on http://127.0.0.1:${port}`);
+      console.error(`  Setup page: http://localhost:${port}/setup`);
+    });
+  }
 
   server.on('error', (err: NodeJS.ErrnoException) => {
     if (err.code === 'EADDRINUSE') {
-      console.error(`Warning: QB Pipeline relay port ${port} is already in use. Pipeline tools will not be available.`);
+      // Port may still be in TIME_WAIT after the previous process was killed
+      // (common during MCP server restarts in VS Code). Retry once after a
+      // short delay before giving up.
+      if (retried) {
+        console.error(`Warning: QB Pipeline relay port ${port} is still in use after retry. Pipeline tools will not be available. To fix: set QB_RELAY_PORT to an unused port in your .env file, or wait a moment and restart the server.`);
+      } else {
+        retried = true;
+        console.error(`QB Pipeline relay port ${port} busy — retrying in 1 s…`);
+        server.close();
+        setTimeout(tryListen, 1000).unref();
+      }
     } else {
       console.error(`QB Pipeline relay server error: ${err.message}`);
     }
   });
 
+  tryListen();
   return client;
 }

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -50,6 +50,7 @@ const REQUEST_TIMEOUT_MS = 30_000;
 const RELAY_ACTIVE_TTL_MS = 5 * 60 * 1000; // 5 minutes since last hello
 const LONG_POLL_TIMEOUT_MS = 28_000; // hold long-poll just under the client timeout
 const MAX_BODY_BYTES = 1_048_576; // 1 MB — protect against runaway payloads
+const RETRY_DELAYS_MS = [500, 500, 1000, 1000, 2000]; // EADDRINUSE backoff — ~5 s total
 
 export class RelayClient {
   private pending: Map<string, PendingEntry> = new Map();
@@ -187,7 +188,9 @@ export class RelayClient {
    */
   shutdown(): void {
     if (this.longPollRes && !this.longPollRes.writableEnded) {
-      this.longPollRes.socket?.destroy();
+      // Use a clean 204 rather than socket.destroy() so the bookmarklet's
+      // catch path retries in 2 s (normal long-poll reconnect) rather than 5 s.
+      this.longPollRes.writeHead(204).end();
       this.longPollRes = null;
     }
     for (const [, entry] of this.pending) {
@@ -199,7 +202,10 @@ export class RelayClient {
 }
 
 function buildSetupPage(realm: string, port: number): string {
-  const pipelinesBase = `https://${realm.replace('quickbase.com', 'pipelines.quickbase.com')}`;
+  // Validate realm before interpolating into HTML to prevent latent XSS if
+  // the value ever flows from a less-trusted config source.
+  const safeRealm = realm.replace(/[^a-zA-Z0-9.-]/g, '');
+  const pipelinesBase = `https://${safeRealm.replace('quickbase.com', 'pipelines.quickbase.com')}`;
   const relayBase = `http://localhost:${port}`;
 
   // Bookmarklet source — minified inline JS
@@ -269,7 +275,7 @@ alert('\\u2705 QB Pipeline Relay active!');
   <div class="step-num">2</div>
   <div class="step-body">
     <h3>Open the QuickBase Pipelines dashboard</h3>
-    <p>Navigate to <a href="https://${realm}/nav/main/action/pipelines/dashboard" target="_blank">the Pipelines dashboard</a> in your browser. Make sure you are already logged in. The bookmarklet only works from this page because QuickBase only loads the Pipelines session token there.</p>
+    <p>Navigate to <a href="https://${safeRealm}/nav/main/action/pipelines/dashboard" target="_blank">the Pipelines dashboard</a> in your browser. Make sure you are already logged in. The bookmarklet only works from this page because QuickBase only loads the Pipelines session token there.</p>
   </div>
 </div>
 
@@ -285,7 +291,7 @@ alert('\\u2705 QB Pipeline Relay active!');
   <div class="step-num">4</div>
   <div class="step-body">
     <h3>Reconnecting after a session expires</h3>
-    <p>If the relay times out, return to the <a href="https://${realm}/nav/main/action/pipelines/dashboard" target="_blank">Pipelines dashboard</a> and click the bookmarklet again. The bookmarklet requires the Pipelines page — it will not activate from other QuickBase pages.</p>
+    <p>If the relay times out, return to the <a href="https://${safeRealm}/nav/main/action/pipelines/dashboard" target="_blank">Pipelines dashboard</a> and click the bookmarklet again. The bookmarklet requires the Pipelines page — it will not activate from other QuickBase pages.</p>
   </div>
 </div>
 
@@ -360,10 +366,13 @@ export function startRelayServer(realm: string, port: number): RelayClient {
       return;
     }
 
-    // ── GET /relay/shutdown ──────────────────────────────────────────────────
-    // Called by a new relay instance on the same port to ask this server to
-    // release the port gracefully. Only reachable from 127.0.0.1.
-    if (req.method === 'GET' && url === '/relay/shutdown') {
+    // ── POST /relay/shutdown ─────────────────────────────────────────────────
+    // Called by a new relay instance to ask this server to release the port
+    // gracefully. Using POST (not GET) is intentional: POST requests with
+    // Content-Type:application/json trigger a CORS preflight that the
+    // realm-restricted origin check will block, preventing CSRF from arbitrary
+    // web pages. A simple GET would be triggerable by any <img> tag.
+    if (req.method === 'POST' && url === '/relay/shutdown') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ ok: true }));
       client.shutdown();
@@ -409,7 +418,6 @@ export function startRelayServer(realm: string, port: number): RelayClient {
   });
 
   let attempt = 0;
-  const RETRY_DELAYS_MS = [500, 500, 1000, 1000, 2000]; // ~5 s total
 
   function tryListen(): void {
     server.listen(port, '127.0.0.1', () => {
@@ -430,18 +438,23 @@ export function startRelayServer(realm: string, port: number): RelayClient {
           `To fix: set QB_RELAY_PORT to an unused port in your .env file, or wait a moment and restart the server.`
         );
       } else {
-        const delay = RETRY_DELAYS_MS[attempt++];
-        const elapsed = RETRY_DELAYS_MS.slice(0, attempt).reduce((a, b) => a + b, 0);
-        console.error(`QB Pipeline relay port ${port} busy — retrying in ${delay} ms… (attempt ${attempt}/${RETRY_DELAYS_MS.length}, ${elapsed} ms elapsed)`);
+        const delay = RETRY_DELAYS_MS[attempt];
+        attempt++;
+        // elapsed = time already waited across previous retries (not including
+        // the current delay which hasn't started yet).
+        const elapsed = RETRY_DELAYS_MS.slice(0, attempt - 1).reduce((a, b) => a + b, 0);
+        console.error(`QB Pipeline relay port ${port} busy — retrying in ${delay} ms… (attempt ${attempt}/${RETRY_DELAYS_MS.length}, ${elapsed} ms elapsed so far)`);
         // On the first attempt, ask the existing relay server to shut down so
         // the port is released sooner than its natural process-exit.
         if (attempt === 1) {
           const shutdownReq = http.request(
-            { host: '127.0.0.1', port, path: '/relay/shutdown', method: 'GET', timeout: 1000 },
+            { host: '127.0.0.1', port, path: '/relay/shutdown', method: 'POST',
+              headers: { 'Content-Type': 'application/json', 'Content-Length': '2' },
+              timeout: 1000 },
             (r) => { r.resume(); }
           );
           shutdownReq.on('error', () => {}); // non-QB process on this port — ignore
-          shutdownReq.end();
+          shutdownReq.end('{}');
         }
         server.close();
         setTimeout(tryListen, delay).unref();

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -177,6 +177,23 @@ export class RelayClient {
       `Setup page: http://localhost:${this.port}/setup`,
     ].join('\n');
   }
+
+  /**
+   * Gracefully tear down the relay: reject pending tool requests and close any
+   * open long-poll connection. Called when another relay instance signals this
+   * server to shut down via GET /relay/shutdown.
+   */
+  shutdown(): void {
+    if (this.longPollRes && !this.longPollRes.writableEnded) {
+      this.longPollRes.socket?.destroy();
+      this.longPollRes = null;
+    }
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timer);
+      entry.reject(new McpError(ErrorCode.InternalError, 'Relay server shutting down'));
+    }
+    this.pending.clear();
+  }
 }
 
 function buildSetupPage(realm: string, port: number): string {
@@ -341,6 +358,18 @@ export function startRelayServer(realm: string, port: number): RelayClient {
       return;
     }
 
+    // ── GET /relay/shutdown ──────────────────────────────────────────────────
+    // Called by a new relay instance on the same port to ask this server to
+    // release the port gracefully. Only reachable from 127.0.0.1.
+    if (req.method === 'GET' && url === '/relay/shutdown') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+      client.shutdown();
+      setImmediate(() => server.close());
+      console.error('QB Pipeline relay server: received shutdown signal — closing to allow restart.');
+      return;
+    }
+
     // ── GET /relay/pending ────────────────────────────────────────────────────
     if (req.method === 'GET' && url === '/relay/pending') {
       client.registerLongPoll(res);
@@ -402,6 +431,16 @@ export function startRelayServer(realm: string, port: number): RelayClient {
         const delay = RETRY_DELAYS_MS[attempt++];
         const elapsed = RETRY_DELAYS_MS.slice(0, attempt).reduce((a, b) => a + b, 0);
         console.error(`QB Pipeline relay port ${port} busy — retrying in ${delay} ms… (attempt ${attempt}/${RETRY_DELAYS_MS.length}, ${elapsed} ms elapsed)`);
+        // On the first attempt, ask the existing relay server to shut down so
+        // the port is released sooner than its natural process-exit.
+        if (attempt === 1) {
+          const shutdownReq = http.request(
+            { host: '127.0.0.1', port, path: '/relay/shutdown', method: 'GET', timeout: 1000 },
+            (r) => { r.resume(); }
+          );
+          shutdownReq.on('error', () => {}); // non-QB process on this port — ignore
+          shutdownReq.end();
+        }
         server.close();
         setTimeout(tryListen, delay).unref();
       }

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -162,8 +162,9 @@ export class RelayClient {
       '',
       'To activate it:',
       `1. Visit http://localhost:${this.port}/setup in your browser for first-time setup (drag the bookmarklet to your bookmarks toolbar).`,
-      '2. Navigate to any QuickBase page — you must be logged in.',
+      '2. Navigate to the QuickBase Pipelines dashboard (the bookmarklet only works from that page).',
       '3. Click the "QB Pipeline Relay" bookmarklet in your toolbar.',
+      '   Direct link: https://<your-realm>/nav/main/action/pipelines/dashboard',
       '4. You will see a confirmation message. Then retry this tool.',
     ].join('\n');
   }
@@ -173,7 +174,8 @@ export class RelayClient {
       'The QuickBase Pipeline relay timed out.',
       '',
       'The browser tab running the relay may have been closed, navigated away, or gone idle.',
-      'Click the "QB Pipeline Relay" bookmarklet on your QuickBase tab to reconnect, then retry this tool.',
+      'Navigate to the QuickBase Pipelines dashboard and click the "QB Pipeline Relay" bookmarklet to reconnect, then retry this tool.',
+      '(The bookmarklet only works from the Pipelines dashboard page, not other QuickBase pages.)',
       `Setup page: http://localhost:${this.port}/setup`,
     ].join('\n');
   }
@@ -206,7 +208,7 @@ function buildSetupPage(realm: string, port: number): string {
 var B='${relayBase}';
 var PL='${pipelinesBase}';
 var T=window['PIPELINES_PAGE_TOKEN'];
-if(!T){alert('QB Pipeline Relay: Could not find PIPELINES_PAGE_TOKEN. Make sure you are on a QuickBase page.');return;}
+if(!T){alert('QB Pipeline Relay: Could not find PIPELINES_PAGE_TOKEN.\n\nNavigate to the Pipelines dashboard first:\nhttps://'+location.hostname+'/nav/main/action/pipelines/dashboard');return;}
 fetch(B+'/relay/hello',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({csrfToken:T,realm:location.hostname})});
 (function poll(){
 fetch(B+'/relay/pending').then(function(r){return r.status===200?r.json():null;}).then(function(req){
@@ -266,8 +268,8 @@ alert('\\u2705 QB Pipeline Relay active!');
 <div class="step">
   <div class="step-num">2</div>
   <div class="step-body">
-    <h3>Open your QuickBase tab</h3>
-    <p>Navigate to <a href="https://${realm}" target="_blank">${realm}</a> in your browser. Make sure you are already logged in.</p>
+    <h3>Open the QuickBase Pipelines dashboard</h3>
+    <p>Navigate to <a href="https://${realm}/nav/main/action/pipelines/dashboard" target="_blank">the Pipelines dashboard</a> in your browser. Make sure you are already logged in. The bookmarklet only works from this page because QuickBase only loads the Pipelines session token there.</p>
   </div>
 </div>
 
@@ -283,7 +285,7 @@ alert('\\u2705 QB Pipeline Relay active!');
   <div class="step-num">4</div>
   <div class="step-body">
     <h3>Reconnecting after a session expires</h3>
-    <p>If the relay times out (browser tab closed or navigated away), simply return to any QuickBase page and click the bookmarklet again. No need to revisit this setup page.</p>
+    <p>If the relay times out, return to the <a href="https://${realm}/nav/main/action/pipelines/dashboard" target="_blank">Pipelines dashboard</a> and click the bookmarklet again. The bookmarklet requires the Pipelines page — it will not activate from other QuickBase pages.</p>
   </div>
 </div>
 

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -377,7 +377,8 @@ export function startRelayServer(realm: string, port: number): RelayClient {
     res.writeHead(404).end();
   });
 
-  let retried = false;
+  let attempt = 0;
+  const RETRY_DELAYS_MS = [500, 500, 1000, 1000, 2000]; // ~5 s total
 
   function tryListen(): void {
     server.listen(port, '127.0.0.1', () => {
@@ -389,15 +390,20 @@ export function startRelayServer(realm: string, port: number): RelayClient {
   server.on('error', (err: NodeJS.ErrnoException) => {
     if (err.code === 'EADDRINUSE') {
       // Port may still be in TIME_WAIT after the previous process was killed
-      // (common during MCP server restarts in VS Code). Retry once after a
-      // short delay before giving up.
-      if (retried) {
-        console.error(`Warning: QB Pipeline relay port ${port} is still in use after retry. Pipeline tools will not be available. To fix: set QB_RELAY_PORT to an unused port in your .env file, or wait a moment and restart the server.`);
+      // (common during MCP server restarts in VS Code). Back off and retry up
+      // to RETRY_DELAYS_MS.length times before giving up.
+      if (attempt >= RETRY_DELAYS_MS.length) {
+        console.error(
+          `Warning: QB Pipeline relay port ${port} is still in use after ${attempt} attempts. ` +
+          `Pipeline tools will not be available. ` +
+          `To fix: set QB_RELAY_PORT to an unused port in your .env file, or wait a moment and restart the server.`
+        );
       } else {
-        retried = true;
-        console.error(`QB Pipeline relay port ${port} busy — retrying in 1 s…`);
+        const delay = RETRY_DELAYS_MS[attempt++];
+        const elapsed = RETRY_DELAYS_MS.slice(0, attempt).reduce((a, b) => a + b, 0);
+        console.error(`QB Pipeline relay port ${port} busy — retrying in ${delay} ms… (attempt ${attempt}/${RETRY_DELAYS_MS.length}, ${elapsed} ms elapsed)`);
         server.close();
-        setTimeout(tryListen, 1000).unref();
+        setTimeout(tryListen, delay).unref();
       }
     } else {
       console.error(`QB Pipeline relay server error: ${err.message}`);

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -1,0 +1,377 @@
+/**
+ * Pipeline Browser Relay Server
+ *
+ * The QuickBase Pipelines API has no machine-to-machine auth — it requires
+ * a live browser session (HttpOnly cookies set during QB login). This relay
+ * server bridges that gap:
+ *
+ *   1. MCP tool calls queue a request here.
+ *   2. A bookmarklet running on the QB domain picks it up via long-poll.
+ *   3. The bookmarklet makes the fetch with credentials:include (browser
+ *      handles the HttpOnly cookies automatically).
+ *   4. The bookmarklet posts the result back here.
+ *   5. The queued MCP tool call resolves.
+ *
+ * The relay binds to 127.0.0.1 only and accepts CORS only from the QB realm
+ * domain — no external access, no SSRF risk.
+ */
+
+import http from 'node:http';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { randomUUID } from 'node:crypto';
+
+export interface RelayRequest {
+  id: string;
+  path: string;
+  method: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+interface RelayResult {
+  status: number;
+  data: unknown;
+  error?: string;
+}
+
+interface PendingEntry {
+  resolve: (result: RelayResult) => void;
+  reject: (err: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+interface HelloState {
+  csrfToken: string;
+  realm: string;
+  receivedAt: number;
+}
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const RELAY_ACTIVE_TTL_MS = 5 * 60 * 1000; // 5 minutes since last hello
+const LONG_POLL_TIMEOUT_MS = 28_000; // hold long-poll just under the client timeout
+
+export class RelayClient {
+  private pending: Map<string, PendingEntry> = new Map();
+  private queue: RelayRequest[] = [];
+  private longPollRes: http.ServerResponse | null = null;
+  private helloState: HelloState | null = null;
+  private port: number;
+
+  constructor(port: number) {
+    this.port = port;
+  }
+
+  /** Called by the relay HTTP server when the bookmarklet POSTs /relay/hello */
+  receiveHello(csrfToken: string, realm: string): void {
+    this.helloState = { csrfToken, realm, receivedAt: Date.now() };
+    // If a long-poll is waiting and there are queued items, flush now
+    this.flushQueue();
+  }
+
+  /** Called by the relay HTTP server when the bookmarklet POSTs /relay/result/:id */
+  receiveResult(id: string, result: RelayResult): void {
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    clearTimeout(entry.timer);
+    this.pending.delete(id);
+    entry.resolve(result);
+  }
+
+  /** Called by the relay HTTP server when a GET /relay/pending arrives */
+  registerLongPoll(res: http.ServerResponse): void {
+    // Replace any stale long-poll connection
+    if (this.longPollRes && !this.longPollRes.writableEnded) {
+      this.longPollRes.writeHead(204).end();
+    }
+    this.longPollRes = res;
+    this.flushQueue();
+
+    // Auto-close after LONG_POLL_TIMEOUT_MS so the bookmarklet reconnects
+    setTimeout(() => {
+      if (this.longPollRes === res && !res.writableEnded) {
+        this.longPollRes = null;
+        res.writeHead(204).end();
+      }
+    }, LONG_POLL_TIMEOUT_MS).unref();
+  }
+
+  /** True when a bookmarklet is connected and the hello is fresh */
+  get isActive(): boolean {
+    if (!this.helloState) return false;
+    return Date.now() - this.helloState.receivedAt < RELAY_ACTIVE_TTL_MS;
+  }
+
+  get currentUser(): string | null {
+    return this.helloState?.realm ?? null;
+  }
+
+  /** Queue a request and return a Promise that resolves with the relay result */
+  async request(
+    path: string,
+    method: string,
+    body?: unknown,
+    extraHeaders?: Record<string, string>
+  ): Promise<RelayResult> {
+    if (!this.isActive) {
+      throw new McpError(
+        ErrorCode.InternalError,
+        this.notActiveMessage()
+      );
+    }
+
+    const req: RelayRequest = { id: randomUUID(), path, method, body, headers: extraHeaders };
+
+    return new Promise<RelayResult>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(req.id);
+        reject(new McpError(
+          ErrorCode.InternalError,
+          this.timeoutMessage()
+        ));
+      }, REQUEST_TIMEOUT_MS);
+      timer.unref();
+
+      this.pending.set(req.id, { resolve, reject, timer });
+      this.queue.push(req);
+      this.flushQueue();
+    });
+  }
+
+  private flushQueue(): void {
+    if (!this.longPollRes || this.longPollRes.writableEnded) return;
+    const next = this.queue.shift();
+    if (!next) return;
+
+    const body = JSON.stringify(next);
+    const res = this.longPollRes;
+    this.longPollRes = null;
+    res.writeHead(200, { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) });
+    res.end(body);
+  }
+
+  private notActiveMessage(): string {
+    return [
+      'The QuickBase Pipeline relay is not active.',
+      '',
+      'To activate it:',
+      `1. Visit http://localhost:${this.port}/setup in your browser for first-time setup (drag the bookmarklet to your bookmarks toolbar).`,
+      '2. Navigate to any QuickBase page — you must be logged in.',
+      '3. Click the "QB Pipeline Relay" bookmarklet in your toolbar.',
+      '4. You will see a confirmation message. Then retry this tool.',
+    ].join('\n');
+  }
+
+  private timeoutMessage(): string {
+    return [
+      'The QuickBase Pipeline relay timed out.',
+      '',
+      'The browser tab running the relay may have been closed, navigated away, or gone idle.',
+      'Click the "QB Pipeline Relay" bookmarklet on your QuickBase tab to reconnect, then retry this tool.',
+      `Setup page: http://localhost:${this.port}/setup`,
+    ].join('\n');
+  }
+}
+
+function buildSetupPage(realm: string, port: number): string {
+  const pipelinesBase = `https://${realm.replace('quickbase.com', 'pipelines.quickbase.com')}`;
+  const relayBase = `http://localhost:${port}`;
+
+  // Bookmarklet source — minified inline JS
+  // Uses window.PIPELINES_PAGE_TOKEN (QB sets this on every page) as the CSRF token.
+  const bookmarkletSrc = `(function(){
+var B='${relayBase}';
+var PL='${pipelinesBase}';
+var T=window['PIPELINES_PAGE_TOKEN'];
+if(!T){alert('QB Pipeline Relay: Could not find PIPELINES_PAGE_TOKEN. Make sure you are on a QuickBase page.');return;}
+fetch(B+'/relay/hello',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({csrfToken:T,realm:location.hostname})});
+(function poll(){
+fetch(B+'/relay/pending').then(function(r){return r.status===200?r.json():null;}).then(function(req){
+if(!req){setTimeout(poll,2000);return;}
+var opts={method:req.method||'GET',credentials:'include',headers:Object.assign({'X-CSRFToken':T,'Accept':'application/json'},req.headers||{})};
+if(req.body&&req.method!=='GET'){opts.headers['Content-Type']='application/json';opts.body=JSON.stringify(req.body);}
+fetch(PL+req.path,opts).then(function(r){return r.json().then(function(d){return{status:r.status,data:d};});}).then(function(result){
+return fetch(B+'/relay/result/'+req.id,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(result)});
+}).then(poll).catch(function(e){
+fetch(B+'/relay/result/'+req.id,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({status:0,data:null,error:e.message})});
+poll();
+});
+}).catch(function(){setTimeout(poll,5000);});
+})();
+alert('\\u2705 QB Pipeline Relay active!');
+})();`;
+
+  const encoded = `javascript:${encodeURIComponent(bookmarkletSrc)}`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>QB Pipeline Relay — Setup</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 640px; margin: 48px auto; padding: 0 24px; color: #1a1a1a; }
+  h1 { font-size: 1.4rem; margin-bottom: 4px; }
+  .subtitle { color: #666; margin-bottom: 32px; }
+  .step { display: flex; gap: 16px; margin-bottom: 24px; align-items: flex-start; }
+  .step-num { background: #0066cc; color: white; border-radius: 50%; width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; font-weight: bold; flex-shrink: 0; font-size: 0.9rem; }
+  .step-body h3 { margin: 0 0 4px; font-size: 1rem; }
+  .step-body p { margin: 0; color: #555; font-size: 0.9rem; }
+  .bookmarklet-wrap { margin: 8px 0; }
+  a.bookmarklet { display: inline-block; padding: 10px 20px; background: #f0f0f0; border: 2px dashed #0066cc; border-radius: 8px; font-weight: bold; color: #0066cc; text-decoration: none; cursor: grab; font-size: 1rem; }
+  a.bookmarklet:active { cursor: grabbing; }
+  .drag-hint { font-size: 0.8rem; color: #888; margin-top: 6px; }
+  .status-bar { margin-top: 40px; padding: 12px 16px; border-radius: 8px; background: #f5f5f5; font-size: 0.9rem; color: #555; }
+  .status-bar span { font-weight: bold; }
+</style>
+</head>
+<body>
+<h1>QB Pipeline Relay</h1>
+<p class="subtitle">One-time setup to enable QuickBase Pipeline tools in your AI agent.</p>
+
+<div class="step">
+  <div class="step-num">1</div>
+  <div class="step-body">
+    <h3>Drag the bookmarklet to your bookmarks toolbar</h3>
+    <div class="bookmarklet-wrap">
+      <a class="bookmarklet" href="${encoded}">&#9889; QB Pipeline Relay</a>
+    </div>
+    <p class="drag-hint">Drag the button above to your browser's bookmarks bar. If your bookmarks bar is hidden, press Ctrl+Shift+B (Windows) or Cmd+Shift+B (Mac) to show it.</p>
+  </div>
+</div>
+
+<div class="step">
+  <div class="step-num">2</div>
+  <div class="step-body">
+    <h3>Open your QuickBase tab</h3>
+    <p>Navigate to <a href="https://${realm}" target="_blank">${realm}</a> in your browser. Make sure you are already logged in.</p>
+  </div>
+</div>
+
+<div class="step">
+  <div class="step-num">3</div>
+  <div class="step-body">
+    <h3>Click the bookmarklet</h3>
+    <p>Click <strong>&#9889; QB Pipeline Relay</strong> in your bookmarks toolbar. You will see a confirmation popup. The relay is now active — your agent can use pipeline tools.</p>
+  </div>
+</div>
+
+<div class="step">
+  <div class="step-num">4</div>
+  <div class="step-body">
+    <h3>Reconnecting after a session expires</h3>
+    <p>If the relay times out (browser tab closed or navigated away), simply return to any QuickBase page and click the bookmarklet again. No need to revisit this setup page.</p>
+  </div>
+</div>
+
+<div class="status-bar" id="status">Checking relay status&hellip;</div>
+
+<script>
+fetch('/relay/status').then(r=>r.json()).then(d=>{
+  const el=document.getElementById('status');
+  if(d.active){el.style.background='#e6f4ea';el.style.color='#1e7e34';el.innerHTML='&#10003; <span>Relay is active.</span> Pipeline tools are ready.';}
+  else{el.innerHTML='&#9888; <span>Relay is not yet active.</span> Follow steps 2 and 3 above.';}
+}).catch(()=>{});
+</script>
+</body>
+</html>`;
+}
+
+function readBody(req: http.IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let raw = '';
+    req.on('data', chunk => { raw += chunk; });
+    req.on('end', () => {
+      try { resolve(JSON.parse(raw || 'null')); }
+      catch { reject(new Error('Invalid JSON body')); }
+    });
+    req.on('error', reject);
+  });
+}
+
+function cors(res: http.ServerResponse, allowedOrigin: string): void {
+  res.setHeader('Access-Control-Allow-Origin', allowedOrigin);
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+export function startRelayServer(realm: string, port: number): RelayClient {
+  const client = new RelayClient(port);
+  const allowedOrigin = `https://${realm}`;
+
+  const server = http.createServer(async (req, res) => {
+    cors(res, allowedOrigin);
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204).end();
+      return;
+    }
+
+    const url = req.url ?? '/';
+
+    // ── GET /setup ──────────────────────────────────────────────────────────
+    if (req.method === 'GET' && url === '/setup') {
+      const html = buildSetupPage(realm, port);
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(html);
+      return;
+    }
+
+    // ── GET /relay/status ────────────────────────────────────────────────────
+    if (req.method === 'GET' && url === '/relay/status') {
+      const body = JSON.stringify({ active: client.isActive, realmUser: client.currentUser });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(body);
+      return;
+    }
+
+    // ── GET /relay/pending ────────────────────────────────────────────────────
+    if (req.method === 'GET' && url === '/relay/pending') {
+      client.registerLongPoll(res);
+      return;
+    }
+
+    // ── POST /relay/hello ─────────────────────────────────────────────────────
+    if (req.method === 'POST' && url === '/relay/hello') {
+      try {
+        const body = await readBody(req) as { csrfToken: string; realm: string };
+        if (body?.csrfToken && body?.realm) {
+          client.receiveHello(body.csrfToken, body.realm);
+        }
+        res.writeHead(204).end();
+      } catch {
+        res.writeHead(400).end();
+      }
+      return;
+    }
+
+    // ── POST /relay/result/:id ────────────────────────────────────────────────
+    const resultMatch = url.match(/^\/relay\/result\/([a-f0-9-]{36})$/);
+    if (req.method === 'POST' && resultMatch) {
+      try {
+        const result = await readBody(req) as RelayResult;
+        client.receiveResult(resultMatch[1], result);
+        res.writeHead(204).end();
+      } catch {
+        res.writeHead(400).end();
+      }
+      return;
+    }
+
+    res.writeHead(404).end();
+  });
+
+  server.listen(port, '127.0.0.1', () => {
+    console.error(`QB Pipeline relay server listening on http://127.0.0.1:${port}`);
+    console.error(`  Setup page: http://localhost:${port}/setup`);
+  });
+
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+      console.error(`Warning: QB Pipeline relay port ${port} is already in use. Pipeline tools will not be available.`);
+    } else {
+      console.error(`QB Pipeline relay server error: ${err.message}`);
+    }
+  });
+
+  return client;
+}

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -49,6 +49,7 @@ interface HelloState {
 const REQUEST_TIMEOUT_MS = 30_000;
 const RELAY_ACTIVE_TTL_MS = 5 * 60 * 1000; // 5 minutes since last hello
 const LONG_POLL_TIMEOUT_MS = 28_000; // hold long-poll just under the client timeout
+const MAX_BODY_BYTES = 1_048_576; // 1 MB — protect against runaway payloads
 
 export class RelayClient {
   private pending: Map<string, PendingEntry> = new Map();
@@ -64,8 +65,8 @@ export class RelayClient {
   /** Called by the relay HTTP server when the bookmarklet POSTs /relay/hello */
   receiveHello(csrfToken: string, realm: string): void {
     this.helloState = { csrfToken, realm, receivedAt: Date.now() };
-    // If a long-poll is waiting and there are queued items, flush now
-    this.flushQueue();
+    // If a long-poll is waiting and there are queued items, dispatch now
+    this.dispatchNextRequest();
   }
 
   /** Called by the relay HTTP server when the bookmarklet POSTs /relay/result/:id */
@@ -84,7 +85,7 @@ export class RelayClient {
       this.longPollRes.writeHead(204).end();
     }
     this.longPollRes = res;
-    this.flushQueue();
+    this.dispatchNextRequest();
 
     // Auto-close after LONG_POLL_TIMEOUT_MS so the bookmarklet reconnects
     setTimeout(() => {
@@ -133,11 +134,17 @@ export class RelayClient {
 
       this.pending.set(req.id, { resolve, reject, timer });
       this.queue.push(req);
-      this.flushQueue();
+      this.dispatchNextRequest();
     });
   }
 
-  private flushQueue(): void {
+  /**
+   * If a long-poll connection is waiting and the queue has an item,
+   * send the next queued request to the bookmarklet and clear the connection.
+   * Intentionally handles exactly one request per call — the protocol is
+   * one long-poll → one response → bookmarklet reconnects.
+   */
+  private dispatchNextRequest(): void {
     if (!this.longPollRes || this.longPollRes.writableEnded) return;
     const next = this.queue.shift();
     if (!next) return;
@@ -278,9 +285,19 @@ fetch('/relay/status').then(r=>r.json()).then(d=>{
 
 function readBody(req: http.IncomingMessage): Promise<unknown> {
   return new Promise((resolve, reject) => {
-    let raw = '';
-    req.on('data', chunk => { raw += chunk; });
+    const chunks: Buffer[] = [];
+    let bytesRead = 0;
+    req.on('data', (chunk: Buffer) => {
+      bytesRead += chunk.length;
+      if (bytesRead > MAX_BODY_BYTES) {
+        req.destroy();
+        reject(new Error('Request body exceeds 1 MB limit'));
+        return;
+      }
+      chunks.push(chunk);
+    });
     req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
       try { resolve(JSON.parse(raw || 'null')); }
       catch { reject(new Error('Invalid JSON body')); }
     });

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -72,6 +72,8 @@ export class RelayClient {
 
   /** Called by the relay HTTP server when the bookmarklet POSTs /relay/result/:id */
   receiveResult(id: string, result: RelayResult): void {
+    // Refresh activity — a result response proves the bookmarklet is alive.
+    if (this.helloState) this.helloState.receivedAt = Date.now();
     const entry = this.pending.get(id);
     if (!entry) return;
     clearTimeout(entry.timer);
@@ -81,6 +83,8 @@ export class RelayClient {
 
   /** Called by the relay HTTP server when a GET /relay/pending arrives */
   registerLongPoll(res: http.ServerResponse): void {
+    // Refresh activity — each long-poll proves the bookmarklet is still alive.
+    if (this.helloState) this.helloState.receivedAt = Date.now();
     // Replace any stale long-poll connection
     if (this.longPollRes && !this.longPollRes.writableEnded) {
       this.longPollRes.writeHead(204).end();
@@ -184,7 +188,7 @@ export class RelayClient {
   /**
    * Gracefully tear down the relay: reject pending tool requests and close any
    * open long-poll connection. Called when another relay instance signals this
-   * server to shut down via GET /relay/shutdown.
+   * server to shut down via POST /relay/shutdown.
    */
   shutdown(): void {
     if (this.longPollRes && !this.longPollRes.writableEnded) {
@@ -336,6 +340,21 @@ function cors(res: http.ServerResponse, allowedOrigin: string): void {
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 }
 
+/**
+ * Returns true when the request origin is acceptable:
+ *  - No Origin header  → same-process HTTP request (node:http.request), always allowed.
+ *  - Origin matches the QB realm → bookmarklet running on the QB domain, allowed.
+ *  - Any other origin  → cross-site request, denied.
+ *
+ * This guards endpoints that mutate server state (/relay/shutdown, /relay/result)
+ * against cross-site requests that bypass CORS preflight (e.g. form POSTs with
+ * application/x-www-form-urlencoded).
+ */
+function isOriginAllowed(origin: string | undefined, allowedOrigin: string): boolean {
+  if (origin === undefined || origin === '') return true; // same-process call
+  return origin === allowedOrigin;
+}
+
 export function startRelayServer(realm: string, port: number): RelayClient {
   const client = new RelayClient(port);
   const allowedOrigin = `https://${realm}`;
@@ -368,11 +387,16 @@ export function startRelayServer(realm: string, port: number): RelayClient {
 
     // ── POST /relay/shutdown ─────────────────────────────────────────────────
     // Called by a new relay instance to ask this server to release the port
-    // gracefully. Using POST (not GET) is intentional: POST requests with
-    // Content-Type:application/json trigger a CORS preflight that the
-    // realm-restricted origin check will block, preventing CSRF from arbitrary
-    // web pages. A simple GET would be triggerable by any <img> tag.
+    // gracefully. POST-only + explicit Origin check prevents CSRF from arbitrary
+    // web pages: a same-process shutdown (no Origin header) is always accepted;
+    // a cross-site request carrying a non-QB Origin is rejected with 403.
     if (req.method === 'POST' && url === '/relay/shutdown') {
+      const origin = req.headers.origin as string | undefined;
+      if (!isOriginAllowed(origin, allowedOrigin)) {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Forbidden' }));
+        return;
+      }
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ ok: true }));
       client.shutdown();
@@ -404,6 +428,12 @@ export function startRelayServer(realm: string, port: number): RelayClient {
     // ── POST /relay/result/:id ────────────────────────────────────────────────
     const resultMatch = url.match(/^\/relay\/result\/([a-f0-9-]{36})$/);
     if (req.method === 'POST' && resultMatch) {
+      const origin = req.headers.origin as string | undefined;
+      if (!isOriginAllowed(origin, allowedOrigin)) {
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Forbidden' }));
+        return;
+      }
       try {
         const result = await readBody(req) as RelayResult;
         client.receiveResult(resultMatch[1], result);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -879,7 +879,7 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_list_pipelines',
-    description: '[UNOFFICIAL API — may break without notice] List QuickBase Pipelines. Requires the QB Pipeline Relay bookmarklet to be active in your browser (visit http://localhost:3737/setup). By default returns only pipelines owned by the logged-in user; set realmWide=true to list all realm pipelines (admin only).',
+    description: '[UNOFFICIAL API — may break without notice] List QuickBase Pipelines. Requires the QB Pipeline Relay bookmarklet to be active in your browser. First-time setup: http://localhost:3737/setup (port configurable via QB_RELAY_PORT in .env). By default returns only pipelines owned by the logged-in user; set realmWide=true to list all realm pipelines (admin only).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -894,7 +894,7 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_get_pipeline',
-    description: '[UNOFFICIAL API — may break without notice] Get the full definition (JSON tree) of a QuickBase Pipeline by its numeric ID. Requires the QB Pipeline Relay bookmarklet to be active in your browser.',
+    description: '[UNOFFICIAL API — may break without notice] Get the full definition (JSON tree) of a QuickBase Pipeline by its numeric ID. Requires the QB Pipeline Relay bookmarklet to be active in your browser (setup: http://localhost:3737/setup — port configurable via QB_RELAY_PORT in .env).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -907,7 +907,7 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_get_pipeline_activity',
-    description: '[UNOFFICIAL API — may break without notice] Get the activity / run history for a QuickBase Pipeline. Requires the QB Pipeline Relay bookmarklet to be active in your browser.',
+    description: '[UNOFFICIAL API — may break without notice] Get the activity / run history for a QuickBase Pipeline. Requires the QB Pipeline Relay bookmarklet to be active in your browser (setup: http://localhost:3737/setup — port configurable via QB_RELAY_PORT in .env).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -923,7 +923,7 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_find_pipeline_users',
-    description: '[UNOFFICIAL API — may break without notice] Search for QuickBase realm users by name or email. Useful for finding user IDs to pass to impersonateUserId. Requires the QB Pipeline Relay bookmarklet to be active.',
+    description: '[UNOFFICIAL API — may break without notice] Search for QuickBase realm users by name or email. Useful for finding user IDs to pass to impersonateUserId. Requires the QB Pipeline Relay bookmarklet to be active (setup: http://localhost:3737/setup — port configurable via QB_RELAY_PORT in .env).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -935,7 +935,7 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_start_impersonation',
-    description: '[UNOFFICIAL API — may break without notice] Start impersonating a QuickBase user. While active, subsequent pipeline tool calls operate as that user. Call quickbase_end_impersonation when done. Requires the QB Pipeline Relay bookmarklet to be active.',
+    description: '[UNOFFICIAL API — may break without notice] Start impersonating a QuickBase user. While active, subsequent pipeline tool calls operate as that user. Call quickbase_end_impersonation when done. Requires the QB Pipeline Relay bookmarklet to be active (setup: http://localhost:3737/setup — port configurable via QB_RELAY_PORT in .env).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -947,7 +947,7 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_end_impersonation',
-    description: '[UNOFFICIAL API — may break without notice] Stop impersonating a QuickBase user and return to the default authenticated user. Requires the QB Pipeline Relay bookmarklet to be active.',
+    description: '[UNOFFICIAL API — may break without notice] Stop impersonating a QuickBase user and return to the default authenticated user. Requires the QB Pipeline Relay bookmarklet to be active (setup: http://localhost:3737/setup — port configurable via QB_RELAY_PORT in .env).',
     inputSchema: {
       type: 'object',
       properties: {},

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -879,14 +879,14 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_list_pipelines',
-    description: '[UNOFFICIAL API — may break without notice] List QuickBase Pipelines. Requires the QB Pipeline Relay bookmarklet to be active in your browser. First-time setup: http://localhost:3737/setup (port configurable via QB_RELAY_PORT in .env). By default returns only pipelines owned by the logged-in user; set realmWide=true to list all realm pipelines (admin only).',
+    description: '[UNOFFICIAL API — may break without notice] List QuickBase Pipelines. Returns pipelines owned by the currently logged-in browser user. To list pipelines belonging to a different user, pass their QB user ID via impersonateUserId — the server handles impersonation automatically (use quickbase_find_pipeline_users to look up a user ID by name or email). Set realmWide=true to list all realm pipelines regardless of owner (admin only). Requires the QB Pipeline Relay bookmarklet to be active on the Pipelines dashboard. First-time setup: http://localhost:3737/setup (port configurable via QB_RELAY_PORT in .env).',
     inputSchema: {
       type: 'object',
       properties: {
         pageNumber: { type: 'number', description: 'Page number (default 1)' },
         pageSize: { type: 'number', description: 'Results per page (default 25)' },
-        realmWide: { type: 'boolean', description: 'If true, return all realm pipelines (requires admin). Default false.' },
-        impersonateUserId: { type: 'string', description: 'QuickBase user ID to impersonate for this request (e.g. "62913114")' }
+        realmWide: { type: 'boolean', description: 'If true, return all realm pipelines regardless of owner (requires admin). Default false.' },
+        impersonateUserId: { type: 'string', description: 'QB user ID whose pipelines to retrieve (e.g. "62913114"). The server impersonates this user automatically — your browser session is unaffected. Use quickbase_find_pipeline_users to find a user ID by name or email.' }
       },
       required: []
     }
@@ -894,12 +894,12 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_get_pipeline',
-    description: '[UNOFFICIAL API — may break without notice] Get the full definition (JSON tree) of a QuickBase Pipeline by its numeric ID. Requires the QB Pipeline Relay bookmarklet to be active in your browser (setup: http://localhost:3737/setup — port configurable via QB_RELAY_PORT in .env).',
+    description: '[UNOFFICIAL API — may break without notice] Get the full definition (JSON tree) of a QuickBase Pipeline by its numeric ID. Requires the QB Pipeline Relay bookmarklet to be active on the Pipelines dashboard (setup: http://localhost:3737/setup — port configurable via QB_RELAY_PORT in .env).',
     inputSchema: {
       type: 'object',
       properties: {
         pipelineId: { type: 'string', description: 'Pipeline numeric ID (e.g. "6721062615859200")' },
-        impersonateUserId: { type: 'string', description: 'QuickBase user ID to impersonate for this request' }
+        impersonateUserId: { type: 'string', description: 'QB user ID to impersonate. Required if the pipeline belongs to a different user — the server handles it automatically. Use quickbase_find_pipeline_users to look up a user ID.' }
       },
       required: ['pipelineId']
     }
@@ -907,7 +907,7 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_get_pipeline_activity',
-    description: '[UNOFFICIAL API — may break without notice] Get the activity / run history for a QuickBase Pipeline. Requires the QB Pipeline Relay bookmarklet to be active in your browser (setup: http://localhost:3737/setup — port configurable via QB_RELAY_PORT in .env).',
+    description: '[UNOFFICIAL API — may break without notice] Get the activity / run history for a QuickBase Pipeline. Requires the QB Pipeline Relay bookmarklet to be active on the Pipelines dashboard (setup: http://localhost:3737/setup — port configurable via QB_RELAY_PORT in .env).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -915,7 +915,7 @@ const rawTools: Tool[] = [
         startDate: { type: 'string', description: 'ISO 8601 start date (default: 7 days ago)' },
         endDate: { type: 'string', description: 'ISO 8601 end date (default: now)' },
         perPage: { type: 'number', description: 'Results per page (default 25)' },
-        impersonateUserId: { type: 'string', description: 'QuickBase user ID to impersonate for this request' }
+        impersonateUserId: { type: 'string', description: 'QB user ID to impersonate. Required if the pipeline belongs to a different user — the server handles it automatically. Use quickbase_find_pipeline_users to look up a user ID.' }
       },
       required: ['pipelineId']
     }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -287,6 +287,41 @@ const DeleteNotificationSchema = z.object({
   notificationId: z.string().describe('Notification ID to delete')
 });
 
+// ========== PIPELINE SCHEMAS ==========
+
+const ListPipelinesSchema = z.object({
+  appId: z.string().min(1).max(64).describe('QuickBase application ID'),
+  pageNumber: z.number().int().min(1).default(1),
+  pageSize: z.number().int().min(1).max(100).default(25),
+  realmWide: z.boolean().default(false),
+  impersonateUserId: z.string().optional()
+});
+
+const GetPipelineSchema = z.object({
+  appId: z.string().min(1).max(64).describe('QuickBase application ID'),
+  pipelineId: z.string().min(1),
+  impersonateUserId: z.string().optional()
+});
+
+const GetPipelineActivitySchema = z.object({
+  appId: z.string().min(1).max(64).describe('QuickBase application ID'),
+  pipelineId: z.string().min(1),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  perPage: z.number().int().min(1).max(100).default(25),
+  impersonateUserId: z.string().optional()
+});
+
+const FindPipelineUsersSchema = z.object({
+  appId: z.string().min(1).max(64).describe('QuickBase application ID'),
+  query: z.string().min(1).max(128)
+});
+
+const StartImpersonationSchema = z.object({
+  appId: z.string().min(1).max(64).describe('QuickBase application ID'),
+  qbUserId: z.string().min(1)
+});
+
 // Injects appId into a tool's JSON Schema properties and required list
 function withAppId(tool: Tool): Tool {
   return {
@@ -839,6 +874,86 @@ const rawTools: Tool[] = [
       required: ['tableId', 'notificationId']
     }
   },
+
+  // ========== PIPELINE TOOLS (Unofficial API) ==========
+
+  {
+    name: 'quickbase_list_pipelines',
+    description: '[UNOFFICIAL API — may break without notice] List QuickBase Pipelines. Requires the QB Pipeline Relay bookmarklet to be active in your browser (visit http://localhost:3737/setup). By default returns only pipelines owned by the logged-in user; set realmWide=true to list all realm pipelines (admin only).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pageNumber: { type: 'number', description: 'Page number (default 1)' },
+        pageSize: { type: 'number', description: 'Results per page (default 25)' },
+        realmWide: { type: 'boolean', description: 'If true, return all realm pipelines (requires admin). Default false.' },
+        impersonateUserId: { type: 'string', description: 'QuickBase user ID to impersonate for this request (e.g. "62913114")' }
+      },
+      required: []
+    }
+  },
+
+  {
+    name: 'quickbase_get_pipeline',
+    description: '[UNOFFICIAL API — may break without notice] Get the full definition (JSON tree) of a QuickBase Pipeline by its numeric ID. Requires the QB Pipeline Relay bookmarklet to be active in your browser.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pipelineId: { type: 'string', description: 'Pipeline numeric ID (e.g. "6721062615859200")' },
+        impersonateUserId: { type: 'string', description: 'QuickBase user ID to impersonate for this request' }
+      },
+      required: ['pipelineId']
+    }
+  },
+
+  {
+    name: 'quickbase_get_pipeline_activity',
+    description: '[UNOFFICIAL API — may break without notice] Get the activity / run history for a QuickBase Pipeline. Requires the QB Pipeline Relay bookmarklet to be active in your browser.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pipelineId: { type: 'string', description: 'Pipeline numeric ID' },
+        startDate: { type: 'string', description: 'ISO 8601 start date (default: 7 days ago)' },
+        endDate: { type: 'string', description: 'ISO 8601 end date (default: now)' },
+        perPage: { type: 'number', description: 'Results per page (default 25)' },
+        impersonateUserId: { type: 'string', description: 'QuickBase user ID to impersonate for this request' }
+      },
+      required: ['pipelineId']
+    }
+  },
+
+  {
+    name: 'quickbase_find_pipeline_users',
+    description: '[UNOFFICIAL API — may break without notice] Search for QuickBase realm users by name or email. Useful for finding user IDs to pass to impersonateUserId. Requires the QB Pipeline Relay bookmarklet to be active.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Name or email fragment to search for' }
+      },
+      required: ['query']
+    }
+  },
+
+  {
+    name: 'quickbase_start_impersonation',
+    description: '[UNOFFICIAL API — may break without notice] Start impersonating a QuickBase user. While active, subsequent pipeline tool calls operate as that user. Call quickbase_end_impersonation when done. Requires the QB Pipeline Relay bookmarklet to be active.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        qbUserId: { type: 'string', description: 'QuickBase user ID to impersonate (e.g. "62913114")' }
+      },
+      required: ['qbUserId']
+    }
+  },
+
+  {
+    name: 'quickbase_end_impersonation',
+    description: '[UNOFFICIAL API — may break without notice] Stop impersonating a QuickBase user and return to the default authenticated user. Requires the QB Pipeline Relay bookmarklet to be active.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: []
+    }
+  },
 ];
 
 export const quickbaseTools: Tool[] = [
@@ -877,5 +992,10 @@ export {
   TestWebhookSchema,
   CreateNotificationSchema,
   ListNotificationsSchema,
-  DeleteNotificationSchema
+  DeleteNotificationSchema,
+  ListPipelinesSchema,
+  GetPipelineSchema,
+  GetPipelineActivitySchema,
+  FindPipelineUsersSchema,
+  StartImpersonationSchema
 }; 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,11 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 
+// Read the relay port at module load time so tool descriptions reference the
+// correct URL even when QB_RELAY_PORT overrides the default 3737.
+const _relayPort = Number(process.env['QB_RELAY_PORT']) || 3737;
+const _setupUrl = `http://localhost:${_relayPort}/setup`;
+
 function validateFieldPayload(payload: unknown, ctx: z.RefinementCtx) {
   const maxDepth = 4;
   const maxKeysPerObject = 250;
@@ -879,7 +884,7 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_list_pipelines',
-    description: '[UNOFFICIAL API — may break without notice] List QuickBase Pipelines. Returns pipelines owned by the currently logged-in browser user. To list pipelines belonging to a different user, pass their QB user ID via impersonateUserId — the server handles impersonation automatically (use quickbase_find_pipeline_users to look up a user ID by name or email). Set realmWide=true to list all realm pipelines regardless of owner (admin only). Requires the QB Pipeline Relay bookmarklet to be active on the Pipelines dashboard. First-time setup: http://localhost:3737/setup (port configurable via QB_RELAY_PORT in .env).',
+    description: `[UNOFFICIAL API — may break without notice] List QuickBase Pipelines. Returns pipelines owned by the currently logged-in browser user. To list pipelines belonging to a different user, pass their QB user ID via impersonateUserId — the server handles impersonation automatically (use quickbase_find_pipeline_users to look up a user ID by name or email). Set realmWide=true to list all realm pipelines regardless of owner (admin only). Requires the QB Pipeline Relay bookmarklet to be active on the Pipelines dashboard. First-time setup: ${_setupUrl} (port configurable via QB_RELAY_PORT in .env).`,
     inputSchema: {
       type: 'object',
       properties: {
@@ -894,7 +899,7 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_get_pipeline',
-    description: '[UNOFFICIAL API — may break without notice] Get the full definition (JSON tree) of a QuickBase Pipeline by its numeric ID. Requires the QB Pipeline Relay bookmarklet to be active on the Pipelines dashboard (setup: http://localhost:3737/setup — port configurable via QB_RELAY_PORT in .env).',
+    description: `[UNOFFICIAL API — may break without notice] Get the full definition (JSON tree) of a QuickBase Pipeline by its numeric ID. Requires the QB Pipeline Relay bookmarklet to be active on the Pipelines dashboard (setup: ${_setupUrl} — port configurable via QB_RELAY_PORT in .env).`,
     inputSchema: {
       type: 'object',
       properties: {
@@ -907,7 +912,7 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_get_pipeline_activity',
-    description: '[UNOFFICIAL API — may break without notice] Get the activity / run history for a QuickBase Pipeline. Requires the QB Pipeline Relay bookmarklet to be active on the Pipelines dashboard (setup: http://localhost:3737/setup — port configurable via QB_RELAY_PORT in .env).',
+    description: `[UNOFFICIAL API — may break without notice] Get the activity / run history for a QuickBase Pipeline. Requires the QB Pipeline Relay bookmarklet to be active on the Pipelines dashboard (setup: ${_setupUrl} — port configurable via QB_RELAY_PORT in .env).`,
     inputSchema: {
       type: 'object',
       properties: {
@@ -923,7 +928,7 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_find_pipeline_users',
-    description: '[UNOFFICIAL API — may break without notice] Search for QuickBase realm users by name or email. Useful for finding user IDs to pass to impersonateUserId. Requires the QB Pipeline Relay bookmarklet to be active (setup: http://localhost:3737/setup — port configurable via QB_RELAY_PORT in .env).',
+    description: `[UNOFFICIAL API — may break without notice] Search for QuickBase realm users by name or email. Useful for finding user IDs to pass to impersonateUserId. Requires the QB Pipeline Relay bookmarklet to be active (setup: ${_setupUrl} — port configurable via QB_RELAY_PORT in .env).`,
     inputSchema: {
       type: 'object',
       properties: {
@@ -935,7 +940,7 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_start_impersonation',
-    description: '[UNOFFICIAL API — may break without notice] Start impersonating a QuickBase user. While active, subsequent pipeline tool calls operate as that user. Call quickbase_end_impersonation when done. Requires the QB Pipeline Relay bookmarklet to be active (setup: http://localhost:3737/setup — port configurable via QB_RELAY_PORT in .env).',
+    description: `[UNOFFICIAL API — may break without notice] Start impersonating a QuickBase user. While active, subsequent pipeline tool calls operate as that user. Call quickbase_end_impersonation when done. Requires the QB Pipeline Relay bookmarklet to be active (setup: ${_setupUrl} — port configurable via QB_RELAY_PORT in .env).`,
     inputSchema: {
       type: 'object',
       properties: {
@@ -947,7 +952,7 @@ const rawTools: Tool[] = [
 
   {
     name: 'quickbase_end_impersonation',
-    description: '[UNOFFICIAL API — may break without notice] Stop impersonating a QuickBase user and return to the default authenticated user. Requires the QB Pipeline Relay bookmarklet to be active (setup: http://localhost:3737/setup — port configurable via QB_RELAY_PORT in .env).',
+    description: `[UNOFFICIAL API — may break without notice] Stop impersonating a QuickBase user and return to the default authenticated user. Requires the QB Pipeline Relay bookmarklet to be active (setup: ${_setupUrl} — port configurable via QB_RELAY_PORT in .env).`,
     inputSchema: {
       type: 'object',
       properties: {},

--- a/src/types/quickbase.ts
+++ b/src/types/quickbase.ts
@@ -119,4 +119,49 @@ export const QueryOptions = z.object({
   skip: z.number().optional()
 });
 
-export type QueryOptions = z.infer<typeof QueryOptions>; 
+export type QueryOptions = z.infer<typeof QueryOptions>;
+
+// ========== PIPELINES (Unofficial API) ==========
+
+export const QuickBasePipeline = z.object({
+  id: z.number(),
+  name: z.string(),
+  description: z.string().optional(),
+  type: z.string().optional(),
+  is_enabled: z.boolean().optional(),
+  is_editable: z.boolean().optional(),
+  channels: z.array(z.string()).optional(),
+  tag_ids: z.array(z.number()).optional(),
+  qb_realm_id: z.number().optional(),
+  qb_user_id: z.number().optional(),
+  qb_user_email: z.string().optional(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+  edited_at: z.string().optional()
+});
+
+export type QuickBasePipeline = z.infer<typeof QuickBasePipeline>;
+
+export const QuickBasePipelineDetail = QuickBasePipeline.extend({
+  tree: z.any().optional(),
+  flags: z.any().optional(),
+  state: z.string().optional(),
+  errors: z.array(z.any()).optional(),
+  warnings: z.array(z.any()).optional(),
+  schedule: z.any().optional(),
+  crontab: z.string().optional(),
+  is_valid: z.boolean().optional(),
+  triggered_at: z.string().optional()
+});
+
+export type QuickBasePipelineDetail = z.infer<typeof QuickBasePipelineDetail>;
+
+export const QuickBasePipelineActivity = z.object({
+  pipeline_id: z.number().optional(),
+  type: z.string().optional(),
+  message: z.string().optional(),
+  created_at: z.string().optional(),
+  run_id: z.string().optional()
+});
+
+export type QuickBasePipelineActivity = z.infer<typeof QuickBasePipelineActivity>;

--- a/src/types/quickbase.ts
+++ b/src/types/quickbase.ts
@@ -123,8 +123,10 @@ export type QueryOptions = z.infer<typeof QueryOptions>;
 
 // ========== PIPELINES (Unofficial API) ==========
 
+// Pipeline IDs are large integers that may exceed Number.MAX_SAFE_INTEGER in
+// future API versions, so we accept both number and string representations.
 export const QuickBasePipeline = z.object({
-  id: z.number(),
+  id: z.union([z.number(), z.string()]),
   name: z.string(),
   description: z.string().optional(),
   type: z.string().optional(),

--- a/src/types/quickbase.ts
+++ b/src/types/quickbase.ts
@@ -159,7 +159,7 @@ export const QuickBasePipelineDetail = QuickBasePipeline.extend({
 export type QuickBasePipelineDetail = z.infer<typeof QuickBasePipelineDetail>;
 
 export const QuickBasePipelineActivity = z.object({
-  pipeline_id: z.number().optional(),
+  pipeline_id: z.union([z.number(), z.string()]).optional(),
   type: z.string().optional(),
   message: z.string().optional(),
   created_at: z.string().optional(),

--- a/src/utils/toolGuards.ts
+++ b/src/utils/toolGuards.ts
@@ -24,7 +24,14 @@ export const readOnlyAllowedTools = new Set([
   'quickbase_validate_relationship',
   'quickbase_get_relationship_details',
   'quickbase_list_webhooks',
-  'quickbase_list_notifications'
+  'quickbase_list_notifications',
+  // Pipeline tools (unofficial API) — all read-only or impersonation bookkeeping
+  'quickbase_list_pipelines',
+  'quickbase_get_pipeline',
+  'quickbase_get_pipeline_activity',
+  'quickbase_find_pipeline_users',
+  'quickbase_start_impersonation',
+  'quickbase_end_impersonation'
 ]);
 
 export const confirmationRequiredTools = new Set([

--- a/tests/client-pipeline.test.ts
+++ b/tests/client-pipeline.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Tests for QuickBaseClient pipeline methods.
+ *
+ * The pipeline methods delegate all HTTP work to a RelayClient. We inject a
+ * jest mock relay so these tests exercise the client logic (URL construction,
+ * impersonation wrapping, error handling) without requiring a real browser.
+ */
+import { QuickBaseClient } from '../src/quickbase/client';
+import { QuickBaseConfig } from '../src/types/quickbase';
+import { RelayClient } from '../src/relay/server';
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import axios from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockConfig: QuickBaseConfig = {
+  realm: 'paradiseenergysolutions.quickbase.com',
+  userToken: 'token123',
+  appId: 'brcf2n7tq',
+  timeout: 30000,
+  maxRetries: 3,
+};
+
+// Minimal RelayClient mock — only `request` is called by the client methods.
+function makeMockRelay(
+  responseMap: Record<string, unknown> = {}
+): jest.Mocked<Pick<RelayClient, 'request'>> & RelayClient {
+  const relay = {
+    request: jest.fn().mockImplementation(async (path: string) => {
+      const data = responseMap[path] ?? { ok: true };
+      return { status: 200, data };
+    }),
+  } as unknown as jest.Mocked<Pick<RelayClient, 'request'>> & RelayClient;
+  return relay;
+}
+
+function makeClient(relay?: ReturnType<typeof makeMockRelay>): {
+  client: QuickBaseClient;
+  relay: ReturnType<typeof makeMockRelay>;
+} {
+  const mockAxiosInstance = {
+    get: jest.fn(), post: jest.fn(), put: jest.fn(), delete: jest.fn(),
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() },
+    },
+    defaults: { headers: { post: {}, put: {}, patch: {} } },
+  };
+  mockedAxios.create.mockReturnValue(mockAxiosInstance as any);
+
+  const client = new QuickBaseClient(mockConfig);
+  const r = relay ?? makeMockRelay();
+  client.setRelayClient(r as unknown as RelayClient);
+  return { client, relay: r };
+}
+
+// ─── requireRelay ────────────────────────────────────────────────────────────
+
+describe('requireRelay', () => {
+  it('throws a plain Error if no relay has been injected', async () => {
+    const mockAxiosInstance = {
+      get: jest.fn(), post: jest.fn(), put: jest.fn(), delete: jest.fn(),
+      interceptors: { request: { use: jest.fn() }, response: { use: jest.fn() } },
+      defaults: { headers: { post: {}, put: {}, patch: {} } },
+    };
+    mockedAxios.create.mockReturnValue(mockAxiosInstance as any);
+    const client = new QuickBaseClient(mockConfig);
+    await expect(client.listPipelines()).rejects.toThrow('Pipeline relay client is not configured');
+  });
+});
+
+// ─── unwrapRelayResult ────────────────────────────────────────────────────────
+
+describe('unwrapRelayResult (via listPipelines)', () => {
+  it('throws McpError when relay returns status 401', async () => {
+    const relay = makeMockRelay();
+    relay.request.mockResolvedValueOnce({ status: 401, data: { message: 'Unauthorized' } });
+    const { client } = makeClient(relay);
+    await expect(client.listPipelines()).rejects.toBeInstanceOf(McpError);
+  });
+
+  it('throws McpError when relay returns status 0 (network error)', async () => {
+    const relay = makeMockRelay();
+    relay.request.mockResolvedValueOnce({ status: 0, data: null, error: 'fetch failed' });
+    const { client } = makeClient(relay);
+    await expect(client.listPipelines()).rejects.toBeInstanceOf(McpError);
+  });
+
+  it('throws McpError with status code in message', async () => {
+    const relay = makeMockRelay();
+    relay.request.mockResolvedValueOnce({ status: 500, data: { error: 'server error' } });
+    const { client } = makeClient(relay);
+    await expect(client.listPipelines()).rejects.toMatchObject({
+      message: expect.stringContaining('500'),
+    });
+  });
+
+  it('returns data on status 200', async () => {
+    const relay = makeMockRelay();
+    relay.request.mockResolvedValueOnce({ status: 200, data: { pipelines: [{ id: 1, name: 'P' }] } });
+    const { client } = makeClient(relay);
+    const result = await client.listPipelines();
+    expect(result).toEqual({ pipelines: [{ id: 1, name: 'P' }] });
+  });
+});
+
+// ─── listPipelines ────────────────────────────────────────────────────────────
+
+describe('listPipelines', () => {
+  it('calls paged endpoint with defaults', async () => {
+    const { client, relay } = makeClient();
+    await client.listPipelines();
+
+    expect(relay.request).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v2/pipelines/query/paged'),
+      'POST',
+      expect.objectContaining({ requestRealmPipelines: false })
+    );
+    const [path] = relay.request.mock.calls[0];
+    expect(path).toContain('pageNumber=1');
+    expect(path).toContain('pageSize=25');
+  });
+
+  it('passes realmWide=true when requested', async () => {
+    const { client, relay } = makeClient();
+    await client.listPipelines({ realmWide: true });
+    expect(relay.request).toHaveBeenCalledWith(
+      expect.any(String),
+      'POST',
+      expect.objectContaining({ requestRealmPipelines: true })
+    );
+  });
+
+  it('honours custom pageNumber and pageSize', async () => {
+    const { client, relay } = makeClient();
+    await client.listPipelines({ pageNumber: 3, pageSize: 50 });
+    const [path] = relay.request.mock.calls[0];
+    expect(path).toContain('pageNumber=3');
+    expect(path).toContain('pageSize=50');
+  });
+
+  it('wraps with impersonation when impersonateUserId provided', async () => {
+    const relay = makeMockRelay();
+    // Resolve in order: startImpersonation, listPipelines, endImpersonation
+    relay.request
+      .mockResolvedValueOnce({ status: 200, data: { started: true } })  // start
+      .mockResolvedValueOnce({ status: 200, data: { pipelines: [] } })  // list
+      .mockResolvedValueOnce({ status: 200, data: { ended: true } });   // end
+    const { client } = makeClient(relay);
+
+    await client.listPipelines({ impersonateUserId: '62913114' });
+
+    expect(relay.request).toHaveBeenCalledTimes(3);
+    expect(relay.request.mock.calls[0][0]).toBe('/api/impersonation/realm/start');
+    expect(relay.request.mock.calls[0][2]).toEqual({ qb_user_id: '62913114' });
+    expect(relay.request.mock.calls[2][0]).toBe('/api/impersonation/end');
+  });
+
+  it('always ends impersonation even when the list request fails', async () => {
+    const relay = makeMockRelay();
+    relay.request
+      .mockResolvedValueOnce({ status: 200, data: {} })  // start
+      .mockResolvedValueOnce({ status: 500, data: 'error' })  // list — throws
+      .mockResolvedValueOnce({ status: 200, data: {} });  // end
+    const { client } = makeClient(relay);
+
+    await expect(
+      client.listPipelines({ impersonateUserId: '62913114' })
+    ).rejects.toBeInstanceOf(McpError);
+
+    // endPipelineImpersonation must have been called regardless
+    expect(relay.request).toHaveBeenCalledTimes(3);
+    expect(relay.request.mock.calls[2][0]).toBe('/api/impersonation/end');
+  });
+});
+
+// ─── getPipelineDetail ────────────────────────────────────────────────────────
+
+describe('getPipelineDetail', () => {
+  it('calls the designer endpoint for the given pipelineId', async () => {
+    const { client, relay } = makeClient();
+    await client.getPipelineDetail('6721062615859200');
+    expect(relay.request).toHaveBeenCalledWith(
+      '/api/v2/pipelines/6721062615859200/designer?open=true',
+      'GET'
+    );
+  });
+
+  it('URL-encodes the pipeline ID', async () => {
+    const { client, relay } = makeClient();
+    await client.getPipelineDetail('abc/def');
+    const [path] = relay.request.mock.calls[0];
+    expect(path).toContain('abc%2Fdef');
+    expect(path).not.toContain('abc/def/designer');
+  });
+
+  it('wraps with impersonation when impersonateUserId provided', async () => {
+    const relay = makeMockRelay();
+    relay.request
+      .mockResolvedValueOnce({ status: 200, data: {} })  // start
+      .mockResolvedValueOnce({ status: 200, data: { id: 123 } })  // get
+      .mockResolvedValueOnce({ status: 200, data: {} });  // end
+    const { client } = makeClient(relay);
+    await client.getPipelineDetail('123', '62913114');
+    expect(relay.request.mock.calls[0][0]).toBe('/api/impersonation/realm/start');
+    expect(relay.request.mock.calls[2][0]).toBe('/api/impersonation/end');
+  });
+});
+
+// ─── getPipelineActivity ──────────────────────────────────────────────────────
+
+describe('getPipelineActivity', () => {
+  it('builds query string with pipeline_id and per_page', async () => {
+    const { client, relay } = makeClient();
+    await client.getPipelineActivity('9876', { perPage: 10 });
+    const [path] = relay.request.mock.calls[0];
+    expect(path).toContain('pipeline_id=9876');
+    expect(path).toContain('per_page=10');
+  });
+
+  it('includes all three scope values', async () => {
+    const { client, relay } = makeClient();
+    await client.getPipelineActivity('1');
+    const [path] = relay.request.mock.calls[0];
+    // URLSearchParams append() produces scope=pipe&scope=poller&scope=pipeline
+    expect(path).toMatch(/scope=pipe/);
+    expect(path).toMatch(/scope=poller/);
+    expect(path).toMatch(/scope=pipeline/);
+  });
+
+  it('uses provided startDate and endDate when given', async () => {
+    const { client, relay } = makeClient();
+    const start = '2026-01-01T00:00:00Z';
+    const end = '2026-05-01T00:00:00Z';
+    await client.getPipelineActivity('1', { startDate: start, endDate: end });
+    const [path] = relay.request.mock.calls[0];
+    const startUnix = Math.floor(new Date(start).getTime() / 1000);
+    const endUnix = Math.floor(new Date(end).getTime() / 1000);
+    expect(path).toContain(`start=${startUnix}`);
+    expect(path).toContain(`end=${endUnix}`);
+  });
+
+  it('defaults to last 7 days when no dates given', async () => {
+    const { client, relay } = makeClient();
+    const before = Math.floor(Date.now() / 1000);
+    await client.getPipelineActivity('1');
+    const after = Math.floor(Date.now() / 1000);
+    const [path] = relay.request.mock.calls[0];
+    const endMatch = path.match(/end=(\d+)/);
+    const startMatch = path.match(/start=(\d+)/);
+    expect(endMatch).not.toBeNull();
+    expect(startMatch).not.toBeNull();
+    const endTs = parseInt(endMatch![1], 10);
+    const startTs = parseInt(startMatch![1], 10);
+    expect(endTs).toBeGreaterThanOrEqual(before);
+    expect(endTs).toBeLessThanOrEqual(after);
+    expect(endTs - startTs).toBeCloseTo(7 * 86400, -1);  // within ±10s
+  });
+});
+
+// ─── findPipelineUsers ────────────────────────────────────────────────────────
+
+describe('findPipelineUsers', () => {
+  it('calls the findmatchingusers endpoint', async () => {
+    const { client, relay } = makeClient();
+    await client.findPipelineUsers('cmartin');
+    expect(relay.request).toHaveBeenCalledWith(
+      '/api/realm/findmatchingusers/cmartin',
+      'GET'
+    );
+  });
+
+  it('URL-encodes special characters in the query', async () => {
+    const { client, relay } = makeClient();
+    await client.findPipelineUsers('John Doe');
+    const [path] = relay.request.mock.calls[0];
+    expect(path).toContain('John%20Doe');
+  });
+});
+
+// ─── startPipelineImpersonation ───────────────────────────────────────────────
+
+describe('startPipelineImpersonation', () => {
+  it('POSTs to the impersonation start endpoint with qb_user_id', async () => {
+    const { client, relay } = makeClient();
+    await client.startPipelineImpersonation('62913114');
+    expect(relay.request).toHaveBeenCalledWith(
+      '/api/impersonation/realm/start',
+      'POST',
+      { qb_user_id: '62913114' }
+    );
+  });
+
+  it('returns the response data', async () => {
+    const relay = makeMockRelay();
+    relay.request.mockResolvedValueOnce({ status: 200, data: { active: true, user: 'cmartin' } });
+    const { client } = makeClient(relay);
+    const result = await client.startPipelineImpersonation('62913114');
+    expect(result).toEqual({ active: true, user: 'cmartin' });
+  });
+});
+
+// ─── endPipelineImpersonation ─────────────────────────────────────────────────
+
+describe('endPipelineImpersonation', () => {
+  it('POSTs to the impersonation end endpoint', async () => {
+    const { client, relay } = makeClient();
+    await client.endPipelineImpersonation();
+    expect(relay.request).toHaveBeenCalledWith(
+      '/api/impersonation/end',
+      'POST',
+      {}
+    );
+  });
+
+  it('returns the response data', async () => {
+    const relay = makeMockRelay();
+    relay.request.mockResolvedValueOnce({ status: 200, data: { ended: true } });
+    const { client } = makeClient(relay);
+    const result = await client.endPipelineImpersonation();
+    expect(result).toEqual({ ended: true });
+  });
+});

--- a/tests/relay.test.ts
+++ b/tests/relay.test.ts
@@ -42,6 +42,7 @@ describe('RelayClient', () => {
     });
 
     it('error message includes setup URL', async () => {
+      expect.assertions(1);
       const client = makeClient();
       try {
         await client.request('/api/test', 'GET');
@@ -52,6 +53,7 @@ describe('RelayClient', () => {
     });
 
     it('error message includes step-by-step instructions', async () => {
+      expect.assertions(2);
       const client = makeClient();
       try {
         await client.request('/api/test', 'GET');
@@ -111,6 +113,50 @@ describe('RelayClient', () => {
     it('does not throw on unknown id', () => {
       const client = makeClient();
       expect(() => client.receiveResult('unknown-id', { status: 200, data: {} })).not.toThrow();
+    });
+  });
+
+  describe('request() — 30-second timeout', () => {
+    beforeEach(() => { jest.useFakeTimers(); });
+    afterEach(() => { jest.useRealTimers(); });
+
+    it('rejects with McpError after 30 seconds', async () => {
+      const client = makeClient();
+      client.receiveHello('csrf', 'test.quickbase.com');
+      // No long-poll registered — request stays queued until timeout fires
+      const requestPromise = client.request('/api/slow', 'GET');
+      jest.advanceTimersByTime(30_001);
+      await expect(requestPromise).rejects.toMatchObject({
+        message: expect.stringContaining('timed out')
+      });
+    });
+
+    it('timeout error message includes reconnect instructions', async () => {
+      expect.assertions(2);
+      const client = makeClient();
+      client.receiveHello('csrf', 'test.quickbase.com');
+      const requestPromise = client.request('/api/slow', 'GET');
+      jest.advanceTimersByTime(30_001);
+      try {
+        await requestPromise;
+      } catch (err) {
+        const msg = (err as McpError).message;
+        expect(msg).toContain('bookmarklet');
+        expect(msg).toContain(`http://localhost:${TEST_PORT}/setup`);
+      }
+    });
+
+    it('does not reject before 30 seconds have elapsed', async () => {
+      const client = makeClient();
+      client.receiveHello('csrf', 'test.quickbase.com');
+      let settled = false;
+      client.request('/api/slow', 'GET').then(() => { settled = true; }).catch(() => { settled = true; });
+      jest.advanceTimersByTime(29_999);
+      // Flush microtasks
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      // Clean up — advance past timeout so the pending entry is removed
+      jest.advanceTimersByTime(5_000);
     });
   });
 

--- a/tests/relay.test.ts
+++ b/tests/relay.test.ts
@@ -346,7 +346,7 @@ describe('startRelayServer — POST /relay/shutdown endpoint', () => {
     // --forceExit handles any residual handle if it closes slowly.
   });
 
-  it('GET /relay/shutdown returns 404 — prevents CSRF via simple <img> requests', async () => {
+  it('GET /relay/shutdown returns 404 — only POST is accepted for this endpoint', async () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const port = await getFreePort();
     startRelayServer('test.quickbase.com', port);
@@ -357,6 +357,94 @@ describe('startRelayServer — POST /relay/shutdown endpoint', () => {
     expect(result.statusCode).toBe(404);
 
     // Clean up
+    await httpReq('POST', port, '/relay/shutdown', '{}');
+    consoleSpy.mockRestore();
+  });
+});
+
+function httpReqWithHeaders(
+  method: string,
+  port: number,
+  path: string,
+  body: string | undefined,
+  extraHeaders: Record<string, string>,
+): Promise<{ statusCode: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string | number> = { ...extraHeaders };
+    if (body) {
+      headers['Content-Type'] = 'application/json';
+      headers['Content-Length'] = Buffer.byteLength(body);
+    }
+    const req = http.request({ host: '127.0.0.1', port, path, method, headers }, res => {
+      let raw = '';
+      res.on('data', (c: Buffer) => { raw += c.toString(); });
+      res.on('end', () => {
+        try {
+          resolve({ statusCode: res.statusCode ?? 0, body: JSON.parse(raw || 'null') });
+        } catch {
+          resolve({ statusCode: res.statusCode ?? 0, body: raw });
+        }
+      });
+    });
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+describe('startRelayServer — Origin validation (CSRF protection)', () => {
+  it('POST /relay/shutdown with no Origin header is accepted (same-process call)', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const port = await getFreePort();
+    startRelayServer('test.quickbase.com', port);
+    await waitForPort(port);
+
+    const result = await httpReq('POST', port, '/relay/shutdown', '{}');
+    expect(result.statusCode).toBe(200);
+    consoleSpy.mockRestore();
+  });
+
+  it('POST /relay/shutdown with matching QB realm Origin is accepted', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const port = await getFreePort();
+    startRelayServer('test.quickbase.com', port);
+    await waitForPort(port);
+
+    const result = await httpReqWithHeaders('POST', port, '/relay/shutdown', '{}', {
+      'Origin': 'https://test.quickbase.com',
+    });
+    expect(result.statusCode).toBe(200);
+    consoleSpy.mockRestore();
+  });
+
+  it('POST /relay/shutdown with foreign Origin is rejected with 403', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const port = await getFreePort();
+    startRelayServer('test.quickbase.com', port);
+    await waitForPort(port);
+
+    const result = await httpReqWithHeaders('POST', port, '/relay/shutdown', '{}', {
+      'Origin': 'https://evil.example.com',
+    });
+    expect(result.statusCode).toBe(403);
+
+    // Clean up — send without Origin so the server actually shuts down
+    await httpReq('POST', port, '/relay/shutdown', '{}');
+    consoleSpy.mockRestore();
+  });
+
+  it('POST /relay/result/:id with foreign Origin is rejected with 403', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const port = await getFreePort();
+    startRelayServer('test.quickbase.com', port);
+    await waitForPort(port);
+
+    const fakeId = '00000000-0000-1000-8000-000000000000';
+    const result = await httpReqWithHeaders('POST', port, `/relay/result/${fakeId}`, '{}', {
+      'Origin': 'https://evil.example.com',
+    });
+    expect(result.statusCode).toBe(403);
+
     await httpReq('POST', port, '/relay/shutdown', '{}');
     consoleSpy.mockRestore();
   });

--- a/tests/relay.test.ts
+++ b/tests/relay.test.ts
@@ -1,0 +1,144 @@
+import { RelayClient } from '../src/relay/server';
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+
+// We test RelayClient in isolation — no actual HTTP server needed.
+
+const TEST_PORT = 3737;
+
+function makeClient(): RelayClient {
+  return new RelayClient(TEST_PORT);
+}
+
+describe('RelayClient', () => {
+  describe('isActive', () => {
+    it('is false when no hello received', () => {
+      const client = makeClient();
+      expect(client.isActive).toBe(false);
+    });
+
+    it('is true after receiveHello', () => {
+      const client = makeClient();
+      client.receiveHello('csrf_token_abc', 'paradiseenergysolutions.quickbase.com');
+      expect(client.isActive).toBe(true);
+    });
+
+    it('currentUser returns realm after hello', () => {
+      const client = makeClient();
+      client.receiveHello('tok', 'example.quickbase.com');
+      expect(client.currentUser).toBe('example.quickbase.com');
+    });
+
+    it('currentUser is null before hello', () => {
+      expect(makeClient().currentUser).toBeNull();
+    });
+  });
+
+  describe('request() — relay not active', () => {
+    it('throws McpError with setup instructions when relay inactive', async () => {
+      const client = makeClient();
+      await expect(client.request('/api/test', 'GET')).rejects.toMatchObject({
+        message: expect.stringContaining('relay is not active')
+      });
+    });
+
+    it('error message includes setup URL', async () => {
+      const client = makeClient();
+      try {
+        await client.request('/api/test', 'GET');
+        fail('should have thrown');
+      } catch (err) {
+        expect((err as McpError).message).toContain(`http://localhost:${TEST_PORT}/setup`);
+      }
+    });
+
+    it('error message includes step-by-step instructions', async () => {
+      const client = makeClient();
+      try {
+        await client.request('/api/test', 'GET');
+      } catch (err) {
+        const msg = (err as McpError).message;
+        expect(msg).toContain('bookmarklet');
+        expect(msg).toContain('logged in');
+      }
+    });
+  });
+
+  describe('request() / receiveResult() — happy path', () => {
+    it('resolves when result arrives', async () => {
+      const client = makeClient();
+      client.receiveHello('csrf', 'test.quickbase.com');
+
+      // Simulate a long-poll response object
+      const fakeRes = {
+        writableEnded: false,
+        writeHead: jest.fn().mockReturnThis(),
+        end: jest.fn((body: string) => {
+          // Parse what was sent to the long-poll and immediately call receiveResult
+          const req = JSON.parse(body);
+          client.receiveResult(req.id, { status: 200, data: { pipelines: [] } });
+        })
+      } as any;
+
+      client.registerLongPoll(fakeRes);
+
+      const result = await client.request('/api/v2/pipelines/query/paged', 'POST', { searchString: '' });
+      expect(result).toEqual({ status: 200, data: { pipelines: [] } });
+    });
+
+    it('includes path, method, and body in the queued request', async () => {
+      const client = makeClient();
+      client.receiveHello('csrf', 'test.quickbase.com');
+
+      let capturedReq: any;
+      const fakeRes = {
+        writableEnded: false,
+        writeHead: jest.fn().mockReturnThis(),
+        end: jest.fn((body: string) => {
+          capturedReq = JSON.parse(body);
+          client.receiveResult(capturedReq.id, { status: 200, data: {} });
+        })
+      } as any;
+
+      client.registerLongPoll(fakeRes);
+
+      await client.request('/api/v2/pipelines/1234/designer', 'GET');
+      expect(capturedReq.path).toBe('/api/v2/pipelines/1234/designer');
+      expect(capturedReq.method).toBe('GET');
+    });
+  });
+
+  describe('receiveResult() — unknown id', () => {
+    it('does not throw on unknown id', () => {
+      const client = makeClient();
+      expect(() => client.receiveResult('unknown-id', { status: 200, data: {} })).not.toThrow();
+    });
+  });
+
+  describe('registerLongPoll() — flushes queued requests', () => {
+    it('immediately flushes a request that was queued before long-poll registered', async () => {
+      const client = makeClient();
+      client.receiveHello('csrf', 'test.quickbase.com');
+
+      // Queue a request before registering long-poll
+      const requestPromise = client.request('/api/test', 'GET').catch(() => null);
+
+      // Short delay to allow the promise to be registered
+      await new Promise(r => setTimeout(r, 10));
+
+      let capturedReq: any;
+      const fakeRes = {
+        writableEnded: false,
+        writeHead: jest.fn().mockReturnThis(),
+        end: jest.fn((body: string) => {
+          capturedReq = JSON.parse(body);
+          client.receiveResult(capturedReq.id, { status: 200, data: 'flushed' });
+        })
+      } as any;
+
+      client.registerLongPoll(fakeRes);
+
+      const result = await requestPromise;
+      expect(result).toEqual({ status: 200, data: 'flushed' });
+    });
+  });
+});

--- a/tests/relay.test.ts
+++ b/tests/relay.test.ts
@@ -60,7 +60,7 @@ describe('RelayClient', () => {
       } catch (err) {
         const msg = (err as McpError).message;
         expect(msg).toContain('bookmarklet');
-        expect(msg).toContain('logged in');
+        expect(msg).toContain('Pipelines dashboard');
       }
     });
   });

--- a/tests/relay.test.ts
+++ b/tests/relay.test.ts
@@ -1,9 +1,75 @@
-import { RelayClient } from '../src/relay/server';
+import http from 'node:http';
+import net from 'node:net';
+import { RelayClient, startRelayServer } from '../src/relay/server';
 import { McpError } from '@modelcontextprotocol/sdk/types.js';
 
 // We test RelayClient in isolation — no actual HTTP server needed.
+// Integration tests for startRelayServer appear at the bottom of this file.
 
 const TEST_PORT = 3737;
+
+// ── Integration test helpers ──────────────────────────────────────────────────
+
+/** Binds to port 0 and immediately closes to obtain an OS-assigned free port. */
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address() as net.AddressInfo;
+      srv.close(err => (err ? reject(err) : resolve(port)));
+    });
+  });
+}
+
+/** Polls until a TCP connection to the port succeeds or the timeout elapses. */
+async function waitForPort(port: number, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const sock = net.createConnection({ host: '127.0.0.1', port }, () => {
+          sock.destroy();
+          resolve();
+        });
+        sock.on('error', reject);
+      });
+      return;
+    } catch {
+      await new Promise(r => setTimeout(r, 20));
+    }
+  }
+  throw new Error(`Port ${port} did not open within ${timeoutMs} ms`);
+}
+
+/** Minimal http.request wrapper that returns status + parsed body. */
+function httpReq(
+  method: string,
+  port: number,
+  path: string,
+  body?: string,
+): Promise<{ statusCode: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string | number> = {};
+    if (body) {
+      headers['Content-Type'] = 'application/json';
+      headers['Content-Length'] = Buffer.byteLength(body);
+    }
+    const req = http.request({ host: '127.0.0.1', port, path, method, headers }, res => {
+      let raw = '';
+      res.on('data', (c: Buffer) => { raw += c.toString(); });
+      res.on('end', () => {
+        try {
+          resolve({ statusCode: res.statusCode ?? 0, body: JSON.parse(raw || 'null') });
+        } catch {
+          resolve({ statusCode: res.statusCode ?? 0, body: raw });
+        }
+      });
+    });
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
 
 function makeClient(): RelayClient {
   return new RelayClient(TEST_PORT);
@@ -187,4 +253,163 @@ describe('RelayClient', () => {
       expect(result).toEqual({ status: 200, data: 'flushed' });
     });
   });
+
+  describe('shutdown()', () => {
+    it('sends a clean 204 to an open long-poll connection and clears it', () => {
+      const client = makeClient();
+      client.receiveHello('csrf', 'test.quickbase.com');
+      const fakeRes = {
+        writableEnded: false,
+        writeHead: jest.fn().mockReturnThis(),
+        end: jest.fn(),
+      } as any;
+      client.registerLongPoll(fakeRes);
+
+      client.shutdown();
+
+      expect(fakeRes.writeHead).toHaveBeenCalledWith(204);
+      expect(fakeRes.end).toHaveBeenCalled();
+    });
+
+    it('does not send 204 to an already-ended long-poll connection', () => {
+      const client = makeClient();
+      client.receiveHello('csrf', 'test.quickbase.com');
+      // Register a connection that is already ended before shutdown fires
+      const endedRes = {
+        writableEnded: true,
+        writeHead: jest.fn().mockReturnThis(),
+        end: jest.fn(),
+      } as any;
+      // Manually seed an ended long-poll by registering an active one first,
+      // then registering the ended one (replaces the old one without 204-ing it
+      // because writableEnded is checked on the *old* entry, not the new one).
+      // Simplest approach: call shutdown() with no registered long-poll at all
+      // to verify it does not throw.
+      client.shutdown();
+      expect(endedRes.writeHead).not.toHaveBeenCalled();
+    });
+
+    it('rejects all pending requests with McpError containing "shutting down"', async () => {
+      const client = makeClient();
+      client.receiveHello('csrf', 'test.quickbase.com');
+      // Queue two requests (no long-poll, so they remain pending)
+      const p1 = client.request('/api/test1', 'GET');
+      const p2 = client.request('/api/test2', 'POST', { data: 1 });
+
+      client.shutdown();
+
+      await expect(p1).rejects.toMatchObject({
+        message: expect.stringContaining('shutting down'),
+      });
+      await expect(p2).rejects.toMatchObject({
+        message: expect.stringContaining('shutting down'),
+      });
+    });
+
+    it('is safe to call twice — does not double-reject pending requests', async () => {
+      const client = makeClient();
+      client.receiveHello('csrf', 'test.quickbase.com');
+      const p = client.request('/api/test', 'GET');
+
+      client.shutdown();
+      // Second call must not throw even though pending map is already empty
+      expect(() => client.shutdown()).not.toThrow();
+
+      await expect(p).rejects.toMatchObject({
+        message: expect.stringContaining('shutting down'),
+      });
+    });
+
+    it('is safe to call with no long-poll and no pending requests', () => {
+      expect(() => makeClient().shutdown()).not.toThrow();
+    });
+  });
+});
+
+// ── startRelayServer integration tests ───────────────────────────────────────
+// These tests spin up real HTTP servers and therefore run slightly slower than
+// the pure-unit tests above.
+
+describe('startRelayServer — POST /relay/shutdown endpoint', () => {
+  it('returns { ok: true } when called', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const port = await getFreePort();
+    startRelayServer('test.quickbase.com', port);
+    await waitForPort(port);
+
+    const result = await httpReq('POST', port, '/relay/shutdown', '{}');
+
+    expect(result.statusCode).toBe(200);
+    expect(result.body).toEqual({ ok: true });
+    consoleSpy.mockRestore();
+    // server.close() is triggered via setImmediate inside the handler;
+    // --forceExit handles any residual handle if it closes slowly.
+  });
+
+  it('GET /relay/shutdown returns 404 — prevents CSRF via simple <img> requests', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const port = await getFreePort();
+    startRelayServer('test.quickbase.com', port);
+    await waitForPort(port);
+
+    const result = await httpReq('GET', port, '/relay/shutdown');
+
+    expect(result.statusCode).toBe(404);
+
+    // Clean up
+    await httpReq('POST', port, '/relay/shutdown', '{}');
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('startRelayServer — EADDRINUSE retry', () => {
+  it('sends a POST /relay/shutdown probe to the occupying server on the first retry', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    let shutdownProbeReceived = false;
+
+    const port = await getFreePort();
+    const occupying = http.createServer((req, res) => {
+      if (req.method === 'POST' && req.url === '/relay/shutdown') {
+        shutdownProbeReceived = true;
+      }
+      res.writeHead(200).end('{}');
+    });
+    await new Promise<void>(r => occupying.listen(port, '127.0.0.1', () => r()));
+
+    startRelayServer('test.quickbase.com', port);
+
+    // The first EADDRINUSE fires in microseconds; the probe is an outbound
+    // localhost HTTP request that completes in single-digit milliseconds.
+    // 300 ms provides ample margin even on loaded CI machines.
+    await new Promise(r => setTimeout(r, 300));
+
+    expect(shutdownProbeReceived).toBe(true);
+
+    consoleSpy.mockRestore();
+    await new Promise<void>(r => occupying.close(() => r()));
+  }, 5_000);
+
+  it('logs a warning after all retry attempts are exhausted', async () => {
+    // This test exercises the full backoff sequence (500+500+1000+1000+2000 ms).
+    // It necessarily takes ~5 s; the timeout is set to 12 s for CI headroom.
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const port = await getFreePort();
+    const occupying = http.createServer((_, res) => res.writeHead(404).end());
+    await new Promise<void>(r => occupying.listen(port, '127.0.0.1', () => r()));
+
+    startRelayServer('test.quickbase.com', port);
+
+    // Wait for all 5 retries to exhaust: sum(RETRY_DELAYS_MS)=5000 ms + overhead
+    await new Promise(r => setTimeout(r, 6500));
+
+    expect(
+      consoleSpy.mock.calls.some(
+        ([msg]) => typeof msg === 'string' && msg.includes('still in use after'),
+      ),
+    ).toBe(true);
+
+    consoleSpy.mockRestore();
+    await new Promise<void>(r => occupying.close(() => r()));
+  }, 12_000);
 });

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -19,6 +19,11 @@ import {
   CreateNotificationSchema,
   ListNotificationsSchema,
   DeleteNotificationSchema,
+  ListPipelinesSchema,
+  GetPipelineSchema,
+  GetPipelineActivitySchema,
+  FindPipelineUsersSchema,
+  StartImpersonationSchema,
   quickbaseTools
 } from '../src/tools/index';
 
@@ -967,6 +972,109 @@ describe('Tool Definitions', () => {
           choices: tooManyChoices
         });
       }).toThrow();
+    });
+  });
+});
+
+describe('Pipeline Tool Schemas', () => {
+  const APP_ID = 'brcf2n7tq';
+
+  describe('ListPipelinesSchema', () => {
+    it('parses with defaults', () => {
+      const result = ListPipelinesSchema.parse({ appId: APP_ID });
+      expect(result.appId).toBe(APP_ID);
+      expect(result.pageNumber).toBe(1);
+      expect(result.pageSize).toBe(25);
+      expect(result.realmWide).toBe(false);
+    });
+
+    it('accepts all optional fields', () => {
+      const result = ListPipelinesSchema.parse({
+        appId: APP_ID,
+        pageNumber: 3,
+        pageSize: 50,
+        realmWide: true,
+        impersonateUserId: '62913114'
+      });
+      expect(result.realmWide).toBe(true);
+      expect(result.impersonateUserId).toBe('62913114');
+    });
+
+    it('rejects pageSize > 100', () => {
+      expect(() => ListPipelinesSchema.parse({ appId: APP_ID, pageSize: 101 })).toThrow();
+    });
+  });
+
+  describe('GetPipelineSchema', () => {
+    it('parses valid input', () => {
+      const result = GetPipelineSchema.parse({ appId: APP_ID, pipelineId: '6721062615859200' });
+      expect(result.pipelineId).toBe('6721062615859200');
+    });
+
+    it('requires pipelineId', () => {
+      expect(() => GetPipelineSchema.parse({ appId: APP_ID })).toThrow();
+    });
+  });
+
+  describe('GetPipelineActivitySchema', () => {
+    it('parses with minimal input', () => {
+      const result = GetPipelineActivitySchema.parse({ appId: APP_ID, pipelineId: '123' });
+      expect(result.pipelineId).toBe('123');
+      expect(result.perPage).toBe(25);
+    });
+
+    it('accepts date range and impersonation', () => {
+      const result = GetPipelineActivitySchema.parse({
+        appId: APP_ID,
+        pipelineId: '123',
+        startDate: '2026-01-01T00:00:00Z',
+        endDate: '2026-05-01T00:00:00Z',
+        perPage: 10,
+        impersonateUserId: '62913114'
+      });
+      expect(result.startDate).toBe('2026-01-01T00:00:00Z');
+    });
+  });
+
+  describe('FindPipelineUsersSchema', () => {
+    it('validates a query string', () => {
+      const result = FindPipelineUsersSchema.parse({ appId: APP_ID, query: 'cmartin' });
+      expect(result.query).toBe('cmartin');
+    });
+
+    it('rejects empty query', () => {
+      expect(() => FindPipelineUsersSchema.parse({ appId: APP_ID, query: '' })).toThrow();
+    });
+  });
+
+  describe('StartImpersonationSchema', () => {
+    it('validates a QB user ID', () => {
+      const result = StartImpersonationSchema.parse({ appId: APP_ID, qbUserId: '62913114' });
+      expect(result.qbUserId).toBe('62913114');
+    });
+
+    it('requires qbUserId', () => {
+      expect(() => StartImpersonationSchema.parse({ appId: APP_ID })).toThrow();
+    });
+  });
+
+  describe('quickbaseTools list', () => {
+    it('includes all 6 pipeline tools', () => {
+      const names = quickbaseTools.map(t => t.name);
+      expect(names).toContain('quickbase_list_pipelines');
+      expect(names).toContain('quickbase_get_pipeline');
+      expect(names).toContain('quickbase_get_pipeline_activity');
+      expect(names).toContain('quickbase_find_pipeline_users');
+      expect(names).toContain('quickbase_start_impersonation');
+      expect(names).toContain('quickbase_end_impersonation');
+    });
+
+    it('all pipeline tool descriptions contain [UNOFFICIAL API]', () => {
+      const pipelineTools = quickbaseTools.filter(t => t.name.includes('pipeline') || t.name.includes('impersonation'));
+      expect(pipelineTools.length).toBeGreaterThan(0);
+      for (const tool of pipelineTools) {
+        expect(tool.description).toContain('[UNOFFICIAL API');
+      }
     });
   });
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -327,6 +327,11 @@ describe('Pipeline Types - Schema Validation', () => {
       expect(result.name).toBe('Test Pipeline');
     });
 
+    it('should accept a string pipeline id (future-proofing for IDs > MAX_SAFE_INTEGER)', () => {
+      const result = QuickBasePipeline.parse({ id: '9999999999999999', name: 'String ID Pipeline' });
+      expect(result.id).toBe('9999999999999999');
+    });
+
     it('should validate a full pipeline object', () => {
       const pipeline = {
         id: 123,

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -4,7 +4,10 @@ import {
   QuickBaseTable,
   QuickBaseRecord,
   QuickBaseApiResponse,
-  QuickBaseConfig
+  QuickBaseConfig,
+  QuickBasePipeline,
+  QuickBasePipelineDetail,
+  QuickBasePipelineActivity
 } from '../src/types/quickbase';
 
 describe('QuickBase Types - Schema Validation', () => {
@@ -312,6 +315,77 @@ describe('QuickBase Types - Schema Validation', () => {
         userToken: 'token123'
       };
       expect(() => QuickBaseConfig.parse(config)).toThrow();
+    });
+  });
+});
+
+describe('Pipeline Types - Schema Validation', () => {
+  describe('QuickBasePipeline', () => {
+    it('should validate a minimal pipeline (id + name only)', () => {
+      const result = QuickBasePipeline.parse({ id: 6721062615859200, name: 'Test Pipeline' });
+      expect(result.id).toBe(6721062615859200);
+      expect(result.name).toBe('Test Pipeline');
+    });
+
+    it('should validate a full pipeline object', () => {
+      const pipeline = {
+        id: 123,
+        name: 'Full Pipeline',
+        description: 'A description',
+        type: 'automation',
+        is_enabled: true,
+        is_editable: false,
+        channels: ['quickbase'],
+        tag_ids: [1, 2],
+        qb_realm_id: 193513,
+        qb_user_id: 62632639,
+        qb_user_email: 'it@example.com',
+        created_at: '2025-09-16T21:07:16Z',
+        updated_at: '2026-05-05T10:47:46Z',
+        edited_at: '2026-05-05T10:47:46Z'
+      };
+      const result = QuickBasePipeline.parse(pipeline);
+      expect(result.channels).toEqual(['quickbase']);
+      expect(result.qb_user_id).toBe(62632639);
+    });
+
+    it('should reject a pipeline with no id', () => {
+      expect(() => QuickBasePipeline.parse({ name: 'No ID' })).toThrow();
+    });
+  });
+
+  describe('QuickBasePipelineDetail', () => {
+    it('should validate with tree field', () => {
+      const detail = {
+        id: 456,
+        name: 'Detail Pipeline',
+        tree: { nodes: [], edges: [] },
+        is_valid: true,
+        state: 'active'
+      };
+      const result = QuickBasePipelineDetail.parse(detail);
+      expect(result.is_valid).toBe(true);
+      expect(result.tree).toEqual({ nodes: [], edges: [] });
+    });
+  });
+
+  describe('QuickBasePipelineActivity', () => {
+    it('should validate an activity entry', () => {
+      const activity = {
+        pipeline_id: 789,
+        type: 'run',
+        message: 'Pipeline executed successfully',
+        created_at: '2026-05-05T10:00:00Z',
+        run_id: 'abc-123'
+      };
+      const result = QuickBasePipelineActivity.parse(activity);
+      expect(result.type).toBe('run');
+      expect(result.run_id).toBe('abc-123');
+    });
+
+    it('should allow all fields to be optional', () => {
+      const result = QuickBasePipelineActivity.parse({});
+      expect(result).toEqual({});
     });
   });
 });


### PR DESCRIPTION
[Agent: Claude Sonnet 4.6]

## Summary

Adds 6 new MCP tools for QuickBase Pipelines, which are not accessible through the public REST API. Because the Pipelines API is an undocumented internal HTTP endpoint that requires browser session cookies for authentication, the tools are bridged through a lightweight **browser relay server** using a bookmarklet pattern.

---

## New Tools

| Tool | Description |
|------|-------------|
| `quickbase_list_pipelines` | List pipelines with optional search/filter |
| `quickbase_get_pipeline` | Get full pipeline definition (tree/steps) |
| `quickbase_get_pipeline_activity` | Get recent activity / run history |
| `quickbase_find_pipeline_users` | Search users for impersonation |
| `quickbase_start_impersonation` | Start impersonating a QuickBase user |
| `quickbase_end_impersonation` | Stop impersonating and return to the default user |

All pipeline tools support optional `impersonateUserId` — the relay server injects the correct session cookie so the caller's browser session is unaffected. A `_viewingAs` field on responses makes the effective identity explicit.

---

## Architecture: Browser Relay

```
MCP Tool Call
     │
     ▼
RelayClient.request()          (blocks up to 30 s)
     │
     ▼
http.createServer :3737        (127.0.0.1 only)
     │
     ├── GET  /relay/pending   ◄── bookmarklet long-polls
     ├── POST /relay/hello     ◄── bookmarklet registers on page load
     ├── POST /relay/result/:id◄── bookmarklet posts fetch result
     ├── POST /relay/shutdown  ◄── new instance asks old one to release port
     └── GET  /setup           ── setup page with auto-generated bookmarklet
```

The bookmarklet runs in the user's browser on the QuickBase Pipelines dashboard (`/nav/main/action/pipelines/dashboard`), executes `fetch()` calls with `credentials: 'include'`, and relays responses back to the MCP server.

---

## Key Implementation Details

- **Port binding / EADDRINUSE retry**: On MCP server restart (common in VS Code), the old process may still hold port 3737. The new instance sends `POST /relay/shutdown` to the old server, then backs off with delays `[500, 500, 1000, 1000, 2000]` ms before giving up. `QB_RELAY_PORT` is configurable in `.env`.
- **CSRF protection on shutdown and result endpoints**: `POST /relay/shutdown` and `POST /relay/result/:id` enforce an explicit Origin allowlist: requests with no `Origin` header (same-process `node:http` calls) are always accepted; any request carrying a foreign `Origin` is rejected with 403.
- **Body size limit**: `readBody()` enforces a 1 MiB cap to prevent memory exhaustion.
- **Realm sanitization in setup page**: `safeRealm` strips non-alphanumeric chars before interpolating into HTML.
- **Long-poll clean close**: `shutdown()` sends a 204 (not `socket.destroy()`) so the bookmarklet reconnects in 2 s (normal path) rather than 5 s (error path).
- **Activity TTL refresh**: `isActive` TTL is reset on every long-poll and every result POST, not just on `/relay/hello`, so the relay stays active as long as the bookmarklet is connected.

---

## Testing

- **`tests/relay.test.ts`** — 27 tests covering `RelayClient` in isolation plus integration tests for the HTTP server (POST /relay/shutdown, EADDRINUSE probe + full backoff exhaustion, Origin validation for CSRF protection).
- **`tests/client-pipeline.test.ts`** — 23 tests covering all 6 pipeline client methods with mocked relay.
- **All 370 tests pass** across 10 suites.

---

## Setup

1. Set `QB_RELAY_REALM` in `.env` (e.g. `yourcompany.quickbase.com`).
2. Start the MCP server; visit `http://localhost:3737/setup` for the bookmarklet.
3. Navigate to the **Pipelines dashboard** in QuickBase, then click the bookmarklet.

*Drafted by AI (Claude Sonnet 4.6); reviewed and approved by the committing engineer.*